### PR TITLE
[#30] 다이얼로그 및 마이페이지 수정

### DIFF
--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/ConfirmDialog.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/ConfirmDialog.kt
@@ -6,14 +6,18 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.DialogFragment
+import kr.tekit.lion.daongil.R
 import kr.tekit.lion.daongil.databinding.DialogConfirmBinding
 
 class ConfirmDialog(
-        confirmDialogInterface: ConfirmDialogInterface,
-        title: String,
-        subtitle: String,
-        yesButtonTitle: String)
+    confirmDialogInterface: ConfirmDialogInterface,
+    title: String,
+    subtitle: String,
+    posBtnTitle: String,
+    posBtnColorResId: Int,
+    posBtnTextColorResId: Int)
     : DialogFragment() {
 
     private var _binding: DialogConfirmBinding? = null
@@ -23,12 +27,16 @@ class ConfirmDialog(
 
     private var title: String? = null
     private var subtitle: String? = null
-    private var yesButtonTitle: String? = null
+    private var posBtnTitle: String? = null
+    private var posBtnColorResId: Int? = null
+    private var posBtnTextColorResId: Int? = null
 
     init {
         this.title = title
         this.subtitle = subtitle
-        this.yesButtonTitle = yesButtonTitle
+        this.posBtnTitle = posBtnTitle
+        this.posBtnColorResId = posBtnColorResId
+        this.posBtnTextColorResId = posBtnTextColorResId
         this.confirmDialogInterface = confirmDialogInterface
     }
 
@@ -44,16 +52,18 @@ class ConfirmDialog(
 
         binding.textVeiwDialogTitle.text = title
         binding.textVeiwDialogSubtitle.text = subtitle
-        binding.yesButton.text = yesButtonTitle
+        binding.buttonPositivie.text = posBtnTitle
+        binding.buttonPositivie.backgroundTintList = ContextCompat.getColorStateList(requireContext(), posBtnColorResId ?: R.color.primary)
+        binding.buttonPositivie.setTextColor(ContextCompat.getColor(requireContext(), posBtnTextColorResId ?: R.color.text_primary))
 
         // 취소 버튼 클릭
-        binding.noButton.setOnClickListener {
+        binding.buttonNegative.setOnClickListener {
             dismiss()
         }
 
         // 확인 버튼 클릭
-        binding.yesButton.setOnClickListener {
-            this.confirmDialogInterface?.onYesButtonClick()
+        binding.buttonPositivie.setOnClickListener {
+            this.confirmDialogInterface?.onPosBtnClick()
             dismiss()
         }
 
@@ -67,5 +77,5 @@ class ConfirmDialog(
 }
 
 interface ConfirmDialogInterface {
-    fun onYesButtonClick()
+    fun onPosBtnClick()
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/ConfirmDialog.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/ConfirmDialog.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.DialogFragment
+import kr.tekit.lion.daongil.R
 import kr.tekit.lion.daongil.databinding.DialogConfirmBinding
 
 class ConfirmDialog(
@@ -17,18 +18,11 @@ class ConfirmDialog(
     private val posBtnTitle: String,
     private val posBtnColorResId: Int,
     private val posBtnTextColorResId: Int,
-) : DialogFragment() {
+) : DialogFragment(R.layout.dialog_confirm) {
 
-    private var _binding: DialogConfirmBinding? = null
-    private val binding get() = _binding!!
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = DialogConfirmBinding.inflate(inflater, container, false)
-        val view = binding.root
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val binding = DialogConfirmBinding.bind(view)
 
         dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
 
@@ -46,13 +40,6 @@ class ConfirmDialog(
             confirmDialogInterface.onPosBtnClick()
             dismiss()
         }
-
-        return view
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 }
 

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/ConfirmDialog.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/ConfirmDialog.kt
@@ -8,37 +8,19 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.DialogFragment
-import kr.tekit.lion.daongil.R
 import kr.tekit.lion.daongil.databinding.DialogConfirmBinding
 
 class ConfirmDialog(
-    confirmDialogInterface: ConfirmDialogInterface,
-    title: String,
-    subtitle: String,
-    posBtnTitle: String,
-    posBtnColorResId: Int,
-    posBtnTextColorResId: Int)
-    : DialogFragment() {
+    private val confirmDialogInterface: ConfirmDialogInterface,
+    private val title: String,
+    private val subtitle: String,
+    private val posBtnTitle: String,
+    private val posBtnColorResId: Int,
+    private val posBtnTextColorResId: Int,
+) : DialogFragment() {
 
     private var _binding: DialogConfirmBinding? = null
     private val binding get() = _binding!!
-
-    private var confirmDialogInterface: ConfirmDialogInterface? = null
-
-    private var title: String? = null
-    private var subtitle: String? = null
-    private var posBtnTitle: String? = null
-    private var posBtnColorResId: Int? = null
-    private var posBtnTextColorResId: Int? = null
-
-    init {
-        this.title = title
-        this.subtitle = subtitle
-        this.posBtnTitle = posBtnTitle
-        this.posBtnColorResId = posBtnColorResId
-        this.posBtnTextColorResId = posBtnTextColorResId
-        this.confirmDialogInterface = confirmDialogInterface
-    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -50,20 +32,18 @@ class ConfirmDialog(
 
         dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
 
-        binding.textVeiwDialogTitle.text = title
-        binding.textVeiwDialogSubtitle.text = subtitle
-        binding.buttonPositivie.text = posBtnTitle
-        binding.buttonPositivie.backgroundTintList = ContextCompat.getColorStateList(requireContext(), posBtnColorResId ?: R.color.primary)
-        binding.buttonPositivie.setTextColor(ContextCompat.getColor(requireContext(), posBtnTextColorResId ?: R.color.text_primary))
+        binding.textViewDialogTitle.text = title
+        binding.textViewDialogSubtitle.text = subtitle
+        binding.buttonPositive.text = posBtnTitle
+        binding.buttonPositive.backgroundTintList = ContextCompat.getColorStateList(requireContext(), posBtnColorResId)
+        binding.buttonPositive.setTextColor(ContextCompat.getColor(requireContext(), posBtnTextColorResId))
 
-        // 취소 버튼 클릭
         binding.buttonNegative.setOnClickListener {
             dismiss()
         }
 
-        // 확인 버튼 클릭
-        binding.buttonPositivie.setOnClickListener {
-            this.confirmDialogInterface?.onPosBtnClick()
+        binding.buttonPositive.setOnClickListener {
+            confirmDialogInterface.onPosBtnClick()
             dismiss()
         }
 

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/MyInfoMainFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/MyInfoMainFragment.kt
@@ -67,14 +67,20 @@ class MyInfoMainFragment : Fragment(R.layout.fragment_my_info_main), ConfirmDial
     private fun logoutDialog() {
         // 삭제 버튼 클릭
         binding.layoutLogout.setOnClickListener {
-            val dialog = ConfirmDialog(this, "로그아웃", "해당 기기에서 로그아웃 됩니다.", "로그아웃")
+            val dialog = ConfirmDialog(
+                this,
+                "로그아웃",
+                "해당 기기에서 로그아웃 됩니다.",
+                "로그아웃",
+                R.color.button_tertiary,
+                R.color.white)
             // 알림창이 띄워져있는 동안 배경 클릭 막기
             dialog.isCancelable = false
             dialog.show(activity?.supportFragmentManager!!, "MyPageDialog")
         }
     }
 
-    override fun onYesButtonClick() {
+    override fun onPosBtnClick() {
         logout()
     }
 

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/MyInfoMainFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/MyInfoMainFragment.kt
@@ -65,7 +65,6 @@ class MyInfoMainFragment : Fragment(R.layout.fragment_my_info_main), ConfirmDial
     }
 
     private fun logoutDialog() {
-        // 삭제 버튼 클릭
         binding.layoutLogout.setOnClickListener {
             val dialog = ConfirmDialog(
                 this,
@@ -74,7 +73,6 @@ class MyInfoMainFragment : Fragment(R.layout.fragment_my_info_main), ConfirmDial
                 "로그아웃",
                 R.color.button_tertiary,
                 R.color.white)
-            // 알림창이 띄워져있는 동안 배경 클릭 막기
             dialog.isCancelable = false
             dialog.show(activity?.supportFragmentManager!!, "MyPageDialog")
         }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/MyInfoMainFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/MyInfoMainFragment.kt
@@ -14,26 +14,19 @@ import kr.tekit.lion.daongil.presentation.main.ConfirmDialogInterface
 class MyInfoMainFragment : Fragment(R.layout.fragment_my_info_main), ConfirmDialogInterface {
 
     private var originalStatusBarColor: Int? = null
-    private lateinit var binding: FragmentMyInfoMainBinding
     private var isUser = true
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        binding = FragmentMyInfoMainBinding.bind(view)
+        val binding = FragmentMyInfoMainBinding.bind(view)
 
         changeStatusBarColor()
-        initView()
-        logoutDialog()
+        initView(binding)
+        logoutDialog(binding)
     }
 
-    override fun onDestroyView() {
-        super.onDestroyView()
-
-        restoreStatusBarColor()
-    }
-
-    fun initView() {
+    private fun initView(binding: FragmentMyInfoMainBinding) {
         if(isUser) {
             with(binding) {
                 textViewMyInfoUserNickname.text = "김사자"
@@ -48,7 +41,7 @@ class MyInfoMainFragment : Fragment(R.layout.fragment_my_info_main), ConfirmDial
         }
     }
 
-    fun changeStatusBarColor() {
+    private fun changeStatusBarColor() {
         activity?.let {
             originalStatusBarColor = it.window.statusBarColor
 
@@ -56,7 +49,7 @@ class MyInfoMainFragment : Fragment(R.layout.fragment_my_info_main), ConfirmDial
         }
     }
 
-    fun restoreStatusBarColor() {
+    private fun restoreStatusBarColor() {
         activity?.let {
             originalStatusBarColor?.let { color ->
                 it.window.statusBarColor = color
@@ -64,7 +57,7 @@ class MyInfoMainFragment : Fragment(R.layout.fragment_my_info_main), ConfirmDial
         }
     }
 
-    private fun logoutDialog() {
+    private fun logoutDialog(binding: FragmentMyInfoMainBinding) {
         binding.layoutLogout.setOnClickListener {
             val dialog = ConfirmDialog(
                 this,
@@ -84,5 +77,11 @@ class MyInfoMainFragment : Fragment(R.layout.fragment_my_info_main), ConfirmDial
 
     private fun logout() {
         Snackbar.make(requireView(), "로그아웃", Snackbar.LENGTH_SHORT).show()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+
+        restoreStatusBarColor()
     }
 }

--- a/DaOnGil/app/src/main/res/layout/dialog_confirm.xml
+++ b/DaOnGil/app/src/main/res/layout/dialog_confirm.xml
@@ -12,7 +12,7 @@
     android:padding="@dimen/margin_basic">
 
     <TextView
-        android:id="@+id/textVeiwDialogTitle"
+        android:id="@+id/textViewDialogTitle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:fontFamily="@font/pretendard_medium"
@@ -23,7 +23,7 @@
         tools:text="title" />
 
     <TextView
-        android:id="@+id/textVeiwDialogSubtitle"
+        android:id="@+id/textViewDialogSubtitle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center"
@@ -51,7 +51,7 @@
             app:backgroundTint="@color/button_secondary" />
 
         <Button
-            android:id="@+id/buttonPositivie"
+            android:id="@+id/buttonPositive"
             android:layout_width="0dp"
             android:layout_height="48dp"
             android:layout_weight="1"

--- a/DaOnGil/app/src/main/res/layout/dialog_confirm.xml
+++ b/DaOnGil/app/src/main/res/layout/dialog_confirm.xml
@@ -39,7 +39,7 @@
         android:orientation="horizontal">
 
         <Button
-            android:id="@+id/noButton"
+            android:id="@+id/buttonNegative"
             android:layout_width="0dp"
             android:layout_height="48dp"
             android:layout_marginEnd="@dimen/margin_big4"
@@ -51,7 +51,7 @@
             app:backgroundTint="@color/button_secondary" />
 
         <Button
-            android:id="@+id/yesButton"
+            android:id="@+id/buttonPositivie"
             android:layout_width="0dp"
             android:layout_height="48dp"
             android:layout_weight="1"


### PR DESCRIPTION
## #️⃣연관된 이슈

- #30 

## 📝작업 내용

- 마이페이지 코드 개선
- 동일한 형태의 다이얼로그를 다른 곳에서 재사용할 수 있도록 함
- 버튼 컬러와 버튼 텍스트 컬러를 파라미터로 받아 설정하도록 수정
```kotlin
private fun logoutDialog() {
        binding.layoutLogout.setOnClickListener {
            val dialog = ConfirmDialog(
                this,
                "로그아웃",
                "해당 기기에서 로그아웃 됩니다.",
                "로그아웃",
                R.color.button_tertiary,
                R.color.white)

            // 다이얼로그가 띄워져있는 동안 배경 클릭 막기
            dialog.isCancelable = false

            // dialog.show(manager: FragmentManager, tag: String) 호출 시, manager로 넘겨줄 값
            dialog.show(requireActivity().supportFragmentManager, "MyPageDialog")
        }
}
``` 

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
<img src="https://github.com/APP-Android2/FinalProject-DaOnGil/assets/125721217/869340db-7d0c-4a3e-900e-fdea8f1c6d1c" width="300" /> <img src="https://github.com/APP-Android2/FinalProject-DaOnGil/assets/125721217/0a71aa34-6d7b-4412-ba03-9e44723e809c" width="300" /> 

