### PR TITLE
[#46] feature 홈 고대비모드 설정

### DIFF
--- a/DaOnGil/app/src/main/AndroidManifest.xml
+++ b/DaOnGil/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".HighThemeApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/HighThemeApp.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/HighThemeApp.kt
@@ -1,0 +1,52 @@
+package kr.tekit.lion.daongil
+
+import android.app.Application
+import android.content.Context
+import android.content.SharedPreferences
+
+class HighThemeApp : Application() {
+    init {
+        instance = this
+    }
+
+    companion object {
+        private var instance : HighThemeApp? = null
+
+        fun context(): Context {
+            return instance!!.applicationContext
+        }
+
+        fun getInstance(): HighThemeApp {
+            return instance!!
+        }
+    }
+
+    fun getApplicationPrefs(key: String): SharedPreferences {
+        return context().getSharedPreferences(key, MODE_PRIVATE)
+    }
+
+    fun setThemePrefs(theme: String) {
+        val prefs = getApplicationPrefs("theme_prefs")
+        prefs.edit().putString("theme", theme).apply()
+    }
+
+    fun getThemePrefs(): String? {
+        val prefs = getApplicationPrefs("theme_prefs")
+        return prefs.getString("theme", "")
+    }
+
+    fun isFirstLogin() : Boolean {
+        val prefs = getApplicationPrefs("login_prefs")
+        return prefs.getBoolean("isFirstLogin", true)
+    }
+
+    fun setFirstLogin(isFirstLogin: Boolean) {
+        val prefs = getApplicationPrefs("login_prefs")
+        prefs.edit().putBoolean("isFirstLogin", isFirstLogin).apply()
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        instance = this
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/dialog/ModeSettingDialog.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/dialog/ModeSettingDialog.kt
@@ -5,10 +5,12 @@ import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.DialogFragment
+import kr.tekit.lion.daongil.HighThemeApp
 import kr.tekit.lion.daongil.R
 import kr.tekit.lion.daongil.databinding.DialogModeSettingBinding
 
-class ModeSettingDialog(private val modeSettingDialogInterface: ModeSettingDialogInterface) : DialogFragment(R.layout.dialog_mode_setting) {
+class ModeSettingDialog() : DialogFragment(R.layout.dialog_mode_setting) {
+    private val app = HighThemeApp.getInstance()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -17,16 +19,17 @@ class ModeSettingDialog(private val modeSettingDialogInterface: ModeSettingDialo
         dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
 
         binding.dialogModeNegativeBtn.setOnClickListener {
+            app.setThemePrefs("basic")
+            app.setFirstLogin(false)
             dismiss()
+            requireActivity().recreate()
         }
 
         binding.dialogModePositiveBtn.setOnClickListener {
-            modeSettingDialogInterface.onSettingBtn()
+            app.setThemePrefs("night")
+            app.setFirstLogin(false)
             dismiss()
+            requireActivity().recreate()
         }
-    }
-
-    interface ModeSettingDialogInterface{
-        fun onSettingBtn()
     }
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/HomeMainFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/HomeMainFragment.kt
@@ -5,9 +5,11 @@ import android.os.Handler
 import android.os.Looper
 import androidx.fragment.app.Fragment
 import android.view.View
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.viewpager2.widget.ViewPager2
+import kr.tekit.lion.daongil.HighThemeApp
 import kr.tekit.lion.daongil.R
 import kr.tekit.lion.daongil.databinding.FragmentHomeMainBinding
 import kr.tekit.lion.daongil.domain.model.Tourist
@@ -18,19 +20,36 @@ import kr.tekit.lion.daongil.presentation.main.dialog.ModeSettingDialog
 import java.util.Timer
 import kotlin.concurrent.scheduleAtFixedRate
 
-class HomeMainFragment : Fragment(R.layout.fragment_home_main), ModeSettingDialog.ModeSettingDialogInterface {
+class HomeMainFragment : Fragment(R.layout.fragment_home_main) {
     private val timer = Timer()
     private val handler = Handler(Looper.getMainLooper())
+    private val app = HighThemeApp.getInstance()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val theme = HighThemeApp.getInstance().getThemePrefs()
+
+        when (theme) {
+            "night" -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
+            "basic" -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+            else -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
+        }
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         val binding = FragmentHomeMainBinding.bind(view)
 
+        if (app.isFirstLogin()) {
+            settingDialog()
+        }
+
         settingVPAdapter(binding)
         settingRecommendRVAdapter(binding)
         settingLocationRVAdapter(binding)
-        settingDialog()
+        settingHighcontrastBtn(binding)
     }
 
     private fun settingVPAdapter(binding: FragmentHomeMainBinding) {
@@ -89,12 +108,20 @@ class HomeMainFragment : Fragment(R.layout.fragment_home_main), ModeSettingDialo
     }
 
     private fun settingDialog() {
-        val dialog = ModeSettingDialog(this)
+        val dialog = ModeSettingDialog()
         dialog.isCancelable = false
         dialog.show(activity?.supportFragmentManager!!, "ModeSettingDialog")
     }
 
-    override fun onSettingBtn() {
-        // 고대비모드로 전환
+    private fun settingHighcontrastBtn(binding: FragmentHomeMainBinding) {
+        binding.homeHighcontrastBtn.setOnClickListener {
+            if (app.getThemePrefs() == "basic") {
+                app.setThemePrefs("night")
+                requireActivity().recreate()
+            } else {
+                app.setThemePrefs("basic")
+                requireActivity().recreate()
+            }
+        }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #46 

## 📝작업 내용

- 첫 로그인 시 고대비 테마 설정 다이얼로그 구현
- 홈 툴바 고대비 버튼 클릭 시 테마 반영
- SharedPreferences에 고대비 테마, 첫 로그인 유무 저장

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
- 고대비 테마 적용

https://github.com/APP-Android2/FinalProject-DaOnGil/assets/75196460/55a01619-e065-4f61-a4c9-17b0d769992c



## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - onCreate()에서 프래그먼트의 초기 설정을 해준다고 해서 초기에 (앱을 켤 때) 테마 설정을 onCreate()에서 해주었는데 한번 확인해주세요 ~
  - 첫 로그인 유무 상태 저장을 일단 HighThemeApp에 같이 해두었는데 따로 파일을 만들어서 저장해두는 게 좋을까요?
  - 테마 설정을 할 때 requireActivity().recreate()로 액티비티 전체를 다시 그리게 했는데 이 부분도 이렇게 구현하는 게 맞는지 조금 헷갈리네요!
