### PR TITLE
[#81] 여행지 상세보기 어댑터 코드 수정

### DIFF
--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/home/adapter/DetailInfoRVAdapter.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/home/adapter/DetailInfoRVAdapter.kt
@@ -6,7 +6,7 @@ import androidx.recyclerview.widget.RecyclerView
 import kr.tekit.lion.daongil.databinding.ItemDetailServiceInfoBinding
 import kr.tekit.lion.daongil.domain.model.DetailInfo
 
-class DetailInfoRVAdapter(var infoList: List<DetailInfo>) : RecyclerView.Adapter<DetailInfoRVAdapter.DetailInfoViewHolder>() {
+class DetailInfoRVAdapter(private val infoList: List<DetailInfo>) : RecyclerView.Adapter<DetailInfoRVAdapter.DetailInfoViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DetailInfoViewHolder {
         val binding : ItemDetailServiceInfoBinding = ItemDetailServiceInfoBinding.inflate(

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/home/adapter/DetailReviewRVAdapter.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/home/adapter/DetailReviewRVAdapter.kt
@@ -6,7 +6,7 @@ import androidx.recyclerview.widget.RecyclerView
 import kr.tekit.lion.daongil.databinding.ItemDetailReviewSmallBinding
 import kr.tekit.lion.daongil.domain.model.Review
 
-class DetailReviewRVAdapter(var reviewList : List<Review>) : RecyclerView.Adapter<DetailReviewRVAdapter.DetailReviewViewHolder>() {
+class DetailReviewRVAdapter(private val reviewList : List<Review>) : RecyclerView.Adapter<DetailReviewRVAdapter.DetailReviewViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DetailReviewViewHolder {
         val binding : ItemDetailReviewSmallBinding = ItemDetailReviewSmallBinding.inflate(

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/HomeMainFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/HomeMainFragment.kt
@@ -23,8 +23,6 @@ import java.util.Timer
 import kotlin.concurrent.scheduleAtFixedRate
 
 class HomeMainFragment : Fragment(R.layout.fragment_home_main), HomeRecommendRVAdapter.OnRecommendClickListener {
-    private val timer = Timer()
-    private val handler = Handler(Looper.getMainLooper())
     private val app = HighThemeApp.getInstance()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -70,8 +68,11 @@ class HomeMainFragment : Fragment(R.layout.fragment_home_main), HomeRecommendRVA
     }
 
     private fun startAutoSlide(adpater : HomeVPAdapter, binding: FragmentHomeMainBinding) {
-        // 일정 간격으로 슬라이드 변경 (3초마다)
-        timer.scheduleAtFixedRate(5000, 5000) {
+        val timer = Timer()
+        val handler = Handler(Looper.getMainLooper())
+
+        // 일정 간격으로 슬라이드 변경 (4초마다)
+        timer.scheduleAtFixedRate(3000, 4000) {
             handler.post {
                 val nextItem = binding.homeVp.currentItem + 1
                 if (nextItem < adpater.itemCount) {


### PR DESCRIPTION
## #️⃣연관된 이슈

- #81 

## 📝작업 내용

- DetailInfoRVAdapter, DetailReviewRVAdapter 매개변수 코드 수정
- HomeMainFragment에서 timer, handler 변수가 startAutoSlide 함수 내에서만 사용되고 있어서
원래 전역변수로 선언해뒀었는데 함수 내로 위치 옮겼습니다

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
- 추가적으로 상세보기 UI 구현 PR에 답변을 못달았던 부분 답변 같이 올립니다
<img width="793" alt="스크린샷 2024-06-06 오전 3 23 47" src="https://github.com/APP-Android2/FinalProject-DaOnGil/assets/75196460/e39049fe-22e0-4581-a602-a258477d8967">

- timer, handler 둘 다 startAutoSlide 함수 내에서 사용되는 변수들이고,
startAutoSlide 함수는 홈 뷰페이저에서 카드뷰가 다음 카드뷰로 자동으로 넘어가도록 설정해주는 함수입니다

  - 여기에서 Timer()는 말 그대로 시간을 측정해주는 타이머 클래스 입니다

  - Handler는 주로 UI 스레드와 백그라운드 스레드 간의 통신을 처리하는 데 사용합니다

      - 여기에선 timer가 백그라운드 스레드에서 처리되고 있는데 시간이 지나고 뷰페이저가 슬라이드 되는 것을
      UI 스레드에서 보여줘야 하기 때문에 UI 업데이트를 위해 handler를 사용했습니다 !

      -  +) Main 스레드에서 처리해줘야 하리 때문에 MainLooper를 사용하기 위해 Looper.getMainLooper() 이렇게 얻어와서 사용하고 있습니다

주저리주저리 설명해봤는데 이해가 됐을지 모르겠네요 ㅎㅎ
(저도 사실 자세히는 몰랐는데 덕분에 찾아볼 기회가 됐네요 허허 감삼다)
더 궁금하면 [요 링크](https://brunch.co.kr/@mystoryg/84) 참고해보시면 좋을 것 같아요!

## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - 리팩토링 코드입니당
