### PR TITLE
[#80] 응급 지원 지도 버튼 현위치와 연결

### DIFF
--- a/DaOnGil/app/build.gradle.kts
+++ b/DaOnGil/app/build.gradle.kts
@@ -40,8 +40,8 @@ android {
         buildConfigField("String", "NAVER_MAP_SECRET", "\"$naverMapSecret\"")
 
         //manifest에서 사용
-        /*manifestPlaceholders["KAKAO_NATIVE_KEY"] = "\"$kakaoNativeKey\""
-        manifestPlaceholders["NAVER_MAP_ID"] =  "\"$naverMapId\""
+        /*manifestPlaceholders["KAKAO_NATIVE_KEY"] = kakaoNativeKey
+        manifestPlaceholders["NAVER_MAP_ID"] =  naverMapId
         manifestPlaceholders.put("NAVER_MAP_ID", naverMapId)
         manifestPlaceholders.put("KAKAO_NATIVE_KEY",  kakaoNativeKey)*/
 
@@ -62,13 +62,13 @@ android {
 
         debug {
             isMinifyEnabled = false
-            /*manifestPlaceholders["NAVER_MAP_ID"] = "\"$naverMapId\""
-            manifestPlaceholders["KAKAO_NATIVE_KEY"] = "\"$kakaoNativeKey\""*/
+            /*manifestPlaceholders["NAVER_MAP_ID"] = naverMapId
+            manifestPlaceholders["KAKAO_NATIVE_KEY"] = kakaoNativeKey*/
         }
         release {
             isMinifyEnabled = false
-            /*manifestPlaceholders["NAVER_MAP_ID"] = "\"$naverMapId\""
-            manifestPlaceholders["KAKAO_NATIVE_KEY"] = "\"$kakaoNativeKey\""*/
+            /*manifestPlaceholders["NAVER_MAP_ID"] = naverMapId
+            manifestPlaceholders["KAKAO_NATIVE_KEY"] = kakaoNativeKey*/
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
@@ -105,6 +105,7 @@ dependencies {
     implementation ("com.squareup.retrofit2:converter-moshi:2.11.0")
 
     implementation ("com.squareup.moshi:moshi:1.15.1")
+    implementation ("com.squareup.moshi:moshi-kotlin:1.15.1")
     kapt ("com.squareup.moshi:moshi-kotlin-codegen:1.15.1")
     implementation ("com.squareup.okhttp3:logging-interceptor:4.10.0")
 

--- a/DaOnGil/app/build.gradle.kts
+++ b/DaOnGil/app/build.gradle.kts
@@ -10,9 +10,7 @@ plugins {
 
 val properties = Properties()
 properties.load(project.rootProject.file("local.properties").inputStream())
-val baseUrl = properties.getProperty("base_url")?:""
 val kakaoApiKey = properties.getProperty("kakao_api_key")?:""
-val kakaoNativeKey = properties.getProperty("kakao_native_key")?:""
 val naverMapBase = properties.getProperty("naver_map_base")?:""
 val naverMapId = properties.getProperty("naver_map_id")?:""
 val naverMapSecret = properties.getProperty("naver_map_secret")?:""
@@ -32,23 +30,19 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         // buildConfigField 메서드를 올바르게 호출합니다.
-        buildConfigField("String", "BASE_URL", "\"$baseUrl\"")
-        buildConfigField("String", "KAKAO_API_KEY", "\"$kakaoApiKey\"")
-        buildConfigField("String", "KAKAO_NATIVE_KEY", "\"$kakaoNativeKey\"")
         buildConfigField("String", "NAVER_MAP_BASE", "\"$naverMapBase\"")
         buildConfigField("String", "NAVER_MAP_ID", "\"$naverMapId\"")
         buildConfigField("String", "NAVER_MAP_SECRET", "\"$naverMapSecret\"")
+        buildConfigField("String", "KAKAO_API_KEY", "\"$kakaoApiKey\"")
 
         //manifest에서 사용
-        /*manifestPlaceholders["KAKAO_NATIVE_KEY"] = kakaoNativeKey
         manifestPlaceholders["NAVER_MAP_ID"] =  naverMapId
-        manifestPlaceholders.put("NAVER_MAP_ID", naverMapId)
+        /*manifestPlaceholders.put("NAVER_MAP_ID", naverMapId)
         manifestPlaceholders.put("KAKAO_NATIVE_KEY",  kakaoNativeKey)*/
 
-        manifestPlaceholders.apply {
-            put("KAKAO_NATIVE_KEY", kakaoNativeKey)
+        /*manifestPlaceholders.apply {
             put("NAVER_MAP_ID", naverMapId)
-        }
+        }*/
 
     }
 

--- a/DaOnGil/app/build.gradle.kts
+++ b/DaOnGil/app/build.gradle.kts
@@ -10,8 +10,12 @@ plugins {
 
 val properties = Properties()
 properties.load(project.rootProject.file("local.properties").inputStream())
-val kakaoApiKey = properties.getProperty("kakaoApiKey")?:""
-val nativeAppKey = properties.getProperty("nativeAppKey")?:""
+val baseUrl = properties.getProperty("base_url")?:""
+val kakaoApiKey = properties.getProperty("kakao_api_key")?:""
+val kakaoNativeKey = properties.getProperty("kakao_native_key")?:""
+val naverMapBase = properties.getProperty("naver_map_base")?:""
+val naverMapId = properties.getProperty("naver_map_id")?:""
+val naverMapSecret = properties.getProperty("naver_map_secret")?:""
 
 
 android {
@@ -28,10 +32,24 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         // buildConfigField 메서드를 올바르게 호출합니다.
+        buildConfigField("String", "BASE_URL", "\"$baseUrl\"")
         buildConfigField("String", "KAKAO_API_KEY", "\"$kakaoApiKey\"")
+        buildConfigField("String", "KAKAO_NATIVE_KEY", "\"$kakaoNativeKey\"")
+        buildConfigField("String", "NAVER_MAP_BASE", "\"$naverMapBase\"")
+        buildConfigField("String", "NAVER_MAP_ID", "\"$naverMapId\"")
+        buildConfigField("String", "NAVER_MAP_SECRET", "\"$naverMapSecret\"")
 
         //manifest에서 사용
-        manifestPlaceholders["NATIVE_APP_KEY"] = nativeAppKey
+        /*manifestPlaceholders["KAKAO_NATIVE_KEY"] = "\"$kakaoNativeKey\""
+        manifestPlaceholders["NAVER_MAP_ID"] =  "\"$naverMapId\""
+        manifestPlaceholders.put("NAVER_MAP_ID", naverMapId)
+        manifestPlaceholders.put("KAKAO_NATIVE_KEY",  kakaoNativeKey)*/
+
+        manifestPlaceholders.apply {
+            put("KAKAO_NATIVE_KEY", kakaoNativeKey)
+            put("NAVER_MAP_ID", naverMapId)
+        }
+
     }
 
     kapt {
@@ -41,8 +59,16 @@ android {
     }
 
     buildTypes {
+
+        debug {
+            isMinifyEnabled = false
+            /*manifestPlaceholders["NAVER_MAP_ID"] = "\"$naverMapId\""
+            manifestPlaceholders["KAKAO_NATIVE_KEY"] = "\"$kakaoNativeKey\""*/
+        }
         release {
             isMinifyEnabled = false
+            /*manifestPlaceholders["NAVER_MAP_ID"] = "\"$naverMapId\""
+            manifestPlaceholders["KAKAO_NATIVE_KEY"] = "\"$kakaoNativeKey\""*/
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/DaOnGil/app/src/main/AndroidManifest.xml
+++ b/DaOnGil/app/src/main/AndroidManifest.xml
@@ -58,10 +58,6 @@
             android:name=".presentation.login.LoginActivity"
             android:exported="false" />
 
-        <meta-data
-            android:name="com.naver.maps.map.CLIENT_ID"
-            android:value="s1kt0zadqe" />
-
         <activity
             android:name=".presentation.onboarding.OnBoardingActivity"
             android:exported="true">
@@ -82,13 +78,14 @@
 
                 <data
                     android:host="oauth"
-                    android:scheme="kakao775fd03d3abd4e0e83b3df4d7ea313bc" />
+                    android:scheme="${KAKAO_NATIVE_KEY}" />
+
             </intent-filter>
         </activity>
 
         <meta-data
             android:name="com.naver.maps.map.CLIENT_ID"
-            android:value="s1kt0zadqe" />
+            android:value="${NAVER_MAP_ID}" />
 
     </application>
 

--- a/DaOnGil/app/src/main/AndroidManifest.xml
+++ b/DaOnGil/app/src/main/AndroidManifest.xml
@@ -78,7 +78,7 @@
 
                 <data
                     android:host="oauth"
-                    android:scheme="${KAKAO_NATIVE_KEY}" />
+                    android:scheme="kakao775fd03d3abd4e0e83b3df4d7ea313bc" />
 
             </intent-filter>
         </activity>

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/HighThemeApp.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/HighThemeApp.kt
@@ -3,6 +3,7 @@ package kr.tekit.lion.daongil
 import android.app.Application
 import android.content.Context
 import android.content.SharedPreferences
+import com.kakao.sdk.common.KakaoSdk
 
 class HighThemeApp : Application() {
     init {
@@ -49,6 +50,7 @@ class HighThemeApp : Application() {
         super.onCreate()
         instance = this
         AuthManager.init(this)
+        KakaoSdk.init(this, BuildConfig.KAKAO_API_KEY)
     }
 }
 

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/HighThemeApp.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/HighThemeApp.kt
@@ -50,7 +50,6 @@ class HighThemeApp : Application() {
         super.onCreate()
         instance = this
         AuthManager.init(this)
-        KakaoSdk.init(this, BuildConfig.KAKAO_API_KEY)
     }
 }
 

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/datasource/NaverMapDataSource.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/datasource/NaverMapDataSource.kt
@@ -1,0 +1,12 @@
+package kr.tekit.lion.daongil.data.datasource
+
+import kr.tekit.lion.daongil.data.dto.remote.response.naverMap.ReverseGecodeResponse
+import kr.tekit.lion.daongil.data.network.service.NaverMapService
+
+class NaverMapDataSource(
+    private val naverMapService: NaverMapService
+) {
+    suspend fun getReverseGeoCode(coords: String) : ReverseGecodeResponse {
+        return naverMapService.getReverseGeoCode(coords)
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/naverMap/Area0.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/naverMap/Area0.kt
@@ -1,0 +1,9 @@
+package kr.tekit.lion.daongil.data.dto.remote.response.naverMap
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class Area0(
+    val coords: Coords?,
+    val name: String?
+)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/naverMap/Center.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/naverMap/Center.kt
@@ -1,0 +1,10 @@
+package kr.tekit.lion.daongil.data.dto.remote.response.naverMap
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class Center(
+    val crs: String?,
+    val x: Double?,
+    val y: Double?
+)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/naverMap/Code.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/naverMap/Code.kt
@@ -1,0 +1,10 @@
+package kr.tekit.lion.daongil.data.dto.remote.response.naverMap
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class Code(
+    val id: String?,
+    val mappingId: String?,
+    val type: String?
+)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/naverMap/Coords.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/naverMap/Coords.kt
@@ -1,0 +1,8 @@
+package kr.tekit.lion.daongil.data.dto.remote.response.naverMap
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class Coords(
+    val center: Center?
+)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/naverMap/Region.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/naverMap/Region.kt
@@ -1,0 +1,12 @@
+package kr.tekit.lion.daongil.data.dto.remote.response.naverMap
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class Region(
+    val area0: Area0?,
+    val area1: Area0?,
+    val area2: Area0?,
+    val area3: Area0?,
+    val area4: Area0?
+)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/naverMap/Result.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/naverMap/Result.kt
@@ -1,0 +1,18 @@
+package kr.tekit.lion.daongil.data.dto.remote.response.naverMap
+
+import com.squareup.moshi.JsonClass
+import kr.tekit.lion.daongil.domain.model.ReverseGecode
+
+@JsonClass(generateAdapter = true)
+data class Result(
+    val code: Code?,
+    val name: String?,
+    val region: Region?
+){
+    fun toDomainModel(): ReverseGecode {
+        return ReverseGecode(
+            area = region?.area1?.name,
+            areaDetail = region?.area2?.name
+        )
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/naverMap/ReverseGecodeResponse.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/naverMap/ReverseGecodeResponse.kt
@@ -1,0 +1,18 @@
+package kr.tekit.lion.daongil.data.dto.remote.response.naverMap
+
+import com.squareup.moshi.JsonClass
+import kr.tekit.lion.daongil.domain.model.ReverseGecodes
+
+@JsonClass(generateAdapter = true)
+data class ReverseGecodeResponse(
+    val results: List<Result?>?,
+    val status: Status?
+){
+    fun toDomainModel(): ReverseGecodes {
+        val domainResults = results?.mapNotNull { it?.toDomainModel() } ?: listOf()
+        return ReverseGecodes(
+            code = status?.code,
+            results = domainResults
+        )
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/naverMap/Status.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/naverMap/Status.kt
@@ -1,0 +1,10 @@
+package kr.tekit.lion.daongil.data.dto.remote.response.naverMap
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class Status(
+    val code: Int?,
+    val message: String?,
+    val name: String?
+)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/RetrofitInstance.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/RetrofitInstance.kt
@@ -68,7 +68,7 @@ object RetrofitInstance {
 
     val placeService: PlaceService by lazy {
         Retrofit.Builder()
-            .baseUrl(BuildConfig.BASE_URL)
+            .baseUrl("http://13.124.100.238/")
             .addConverterFactory(MoshiConverterFactory.create().asLenient())
             .client(headerClient)
             .build()

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/RetrofitInstance.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/RetrofitInstance.kt
@@ -47,8 +47,6 @@ object RetrofitInstance {
                     .build()
                 chain.proceed(request)
             }
-            .authenticator(TokenRefreshAuthenticator())
-            .addInterceptor(AuthInterceptor())
             .addInterceptor(HttpLoggingInterceptor{
                 Log.d("MyOkHttpLog", it)
             }.setLevel(HttpLoggingInterceptor.Level.BODY))

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/RetrofitInstance.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/RetrofitInstance.kt
@@ -1,14 +1,17 @@
 package kr.tekit.lion.daongil.data.network
 
 import android.util.Log
+import com.squareup.moshi.Moshi
+import kr.tekit.lion.daongil.BuildConfig
 import kr.tekit.lion.daongil.data.network.service.PlaceService
 import kr.tekit.lion.daongil.data.network.service.KorWithService
-import kr.tekit.lion.daongil.data.network.service.LoginService
+import kr.tekit.lion.daongil.data.network.service.NaverMapService
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.create
+
 
 object RetrofitInstance {
 
@@ -35,6 +38,23 @@ object RetrofitInstance {
             .build()
     }
 
+    private val naverMapClient: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val request = chain.request().newBuilder()
+                    .addHeader("X-NCP-APIGW-API-KEY-ID", BuildConfig.NAVER_MAP_ID)
+                    .addHeader("X-NCP-APIGW-API-KEY", BuildConfig.NAVER_MAP_SECRET)
+                    .build()
+                chain.proceed(request)
+            }
+            .authenticator(TokenRefreshAuthenticator())
+            .addInterceptor(AuthInterceptor())
+            .addInterceptor(HttpLoggingInterceptor{
+                Log.d("MyOkHttpLog", it)
+            }.setLevel(HttpLoggingInterceptor.Level.BODY))
+            .build()
+    }
+
     val korWithService: KorWithService by lazy {
         Retrofit.Builder()
             .baseUrl("https://apis.data.go.kr/B551011/KorWithService1/")
@@ -48,10 +68,24 @@ object RetrofitInstance {
 
     val placeService: PlaceService by lazy {
         Retrofit.Builder()
-            .baseUrl("http://13.124.100.238/")
+            .baseUrl(BuildConfig.BASE_URL)
             .addConverterFactory(MoshiConverterFactory.create().asLenient())
             .client(headerClient)
             .build()
             .create()
     }
+
+
+
+    val naverMapService: NaverMapService by lazy {
+        Retrofit.Builder()
+            .baseUrl(BuildConfig.NAVER_MAP_BASE)
+            .addConverterFactory(MoshiConverterFactory.create(
+                Moshi.Builder()
+                .build()))
+            .client(naverMapClient)
+            .build()
+            .create(NaverMapService::class.java)
+    }
+
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/service/NaverMapService.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/service/NaverMapService.kt
@@ -1,0 +1,16 @@
+package kr.tekit.lion.daongil.data.network.service
+
+import kr.tekit.lion.daongil.data.dto.remote.response.naverMap.ReverseGecodeResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface NaverMapService {
+
+    // Reverse Geocoding (위경도 -> 주소)
+    @GET("map-reversegeocode/v2/gc")
+    suspend fun getReverseGeoCode(
+        @Query("coords") coords: String,
+        @Query("orders") orders: String = "admcode",
+        @Query("output") output: String = "json"
+    ) : ReverseGecodeResponse
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/repository/NaverMapRepositoryImpl.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/repository/NaverMapRepositoryImpl.kt
@@ -1,0 +1,14 @@
+package kr.tekit.lion.daongil.data.repository
+
+import kr.tekit.lion.daongil.data.datasource.NaverMapDataSource
+import kr.tekit.lion.daongil.domain.model.ReverseGecodes
+import kr.tekit.lion.daongil.domain.repository.NaverMapRepository
+
+class NaverMapRepositoryImpl(
+    private val naverMapDataSource: NaverMapDataSource
+) : NaverMapRepository{
+    override suspend fun getReverseGeoCode(coords: String): ReverseGecodes {
+        return naverMapDataSource.getReverseGeoCode(coords).toDomainModel()
+    }
+
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/ReverseGecode.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/ReverseGecode.kt
@@ -1,0 +1,11 @@
+package kr.tekit.lion.daongil.domain.model
+
+data class ReverseGecodes(
+    val code: Int?,
+    val results: List<ReverseGecode>,
+)
+
+data class ReverseGecode(
+    val area: String?,
+    val areaDetail: String?
+)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/repository/NaverMapRepository.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/repository/NaverMapRepository.kt
@@ -1,0 +1,20 @@
+package kr.tekit.lion.daongil.domain.repository
+
+import kr.tekit.lion.daongil.data.datasource.NaverMapDataSource
+import kr.tekit.lion.daongil.data.network.RetrofitInstance
+import kr.tekit.lion.daongil.data.repository.NaverMapRepositoryImpl
+import kr.tekit.lion.daongil.domain.model.ReverseGecodes
+
+interface NaverMapRepository {
+    suspend fun getReverseGeoCode(coords: String): ReverseGecodes
+
+    companion object {
+        fun create(): NaverMapRepositoryImpl{
+            return NaverMapRepositoryImpl(
+                NaverMapDataSource(
+                    RetrofitInstance.naverMapService
+                )
+            )
+        }
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/GetUserLocationRegionUseCase.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/GetUserLocationRegionUseCase.kt
@@ -1,0 +1,14 @@
+package kr.tekit.lion.daongil.domain.usecase
+
+import kr.tekit.lion.daongil.domain.model.ReverseGecodes
+import kr.tekit.lion.daongil.domain.repository.NaverMapRepository
+import kr.tekit.lion.daongil.domain.usecase.base.BaseUseCase
+import kr.tekit.lion.daongil.domain.usecase.base.Result
+
+class GetUserLocationRegionUseCase(
+    private val naverMapRepository: NaverMapRepository
+) : BaseUseCase(){
+    suspend operator fun invoke(coords: String): Result<ReverseGecodes> = execute {
+        naverMapRepository.getReverseGeoCode(coords)
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/emergency/EmergencyMapActivity.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/emergency/EmergencyMapActivity.kt
@@ -28,7 +28,9 @@ import com.naver.maps.map.OnMapReadyCallback
 import com.naver.maps.map.overlay.Marker
 import com.naver.maps.map.overlay.OverlayImage
 import com.naver.maps.map.util.FusedLocationSource
+import kotlinx.coroutines.launch
 import kr.tekit.lion.daongil.R
+import kr.tekit.lion.daongil.data.network.RetrofitInstance
 import kr.tekit.lion.daongil.databinding.ActivityEmergencyMapBinding
 import kr.tekit.lion.daongil.domain.model.EmergencyBottom
 import kr.tekit.lion.daongil.presentation.emergency.fragment.EmergencyAreaDialog
@@ -241,6 +243,13 @@ class EmergencyMapActivity : AppCompatActivity(), OnMapReadyCallback {
             fusedLocationClient.lastLocation.addOnSuccessListener { location: Location? ->
                 val latitude = location?.latitude ?: 35.1798159
                 val longitude = location?.longitude ?: 129.0750222
+                val coords = "$longitude" + "," + "$latitude"
+
+                viewModel.getuserLocationRegion(coords)
+
+                /*lifecycleScope.launch {
+                    viewModel.getuserLocationRegion(coords)
+                }*/
 
                 // 위치 오버레이의 가시성은 기본적으로 false로 지정되어 있습니다. 가시성을 true로 변경하면 지도에 위치 오버레이가 나타납니다.
                 // 파랑색 점, 현재 위치 표시

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/emergency/EmergencyMapActivity.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/emergency/EmergencyMapActivity.kt
@@ -1,6 +1,7 @@
 package kr.tekit.lion.daongil.presentation.emergency
 
 import android.Manifest
+import android.content.Context
 import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.location.Location
@@ -14,7 +15,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.annotation.UiThread
 import androidx.core.app.ActivityCompat
-import androidx.lifecycle.lifecycleScope
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -28,9 +28,7 @@ import com.naver.maps.map.OnMapReadyCallback
 import com.naver.maps.map.overlay.Marker
 import com.naver.maps.map.overlay.OverlayImage
 import com.naver.maps.map.util.FusedLocationSource
-import kotlinx.coroutines.launch
 import kr.tekit.lion.daongil.R
-import kr.tekit.lion.daongil.data.network.RetrofitInstance
 import kr.tekit.lion.daongil.databinding.ActivityEmergencyMapBinding
 import kr.tekit.lion.daongil.domain.model.EmergencyBottom
 import kr.tekit.lion.daongil.presentation.emergency.fragment.EmergencyAreaDialog
@@ -38,7 +36,6 @@ import kr.tekit.lion.daongil.presentation.emergency.fragment.EmergencyBottomShee
 import kr.tekit.lion.daongil.presentation.emergency.vm.EmergencyMapViewModel
 import kr.tekit.lion.daongil.presentation.emergency.vm.EmergencyMapViewModelFactory
 import kr.tekit.lion.daongil.presentation.ext.showPermissionSnackBar
-import kr.tekit.lion.daongil.presentation.main.dialog.ModeSettingDialog
 
 class EmergencyMapActivity : AppCompatActivity(), OnMapReadyCallback {
 
@@ -213,7 +210,7 @@ class EmergencyMapActivity : AppCompatActivity(), OnMapReadyCallback {
             ?: MapFragment.newInstance().also {
                 fm.beginTransaction().add(R.id.map, it).commit()
             }
-        mapFragment.getMapAsync(this)
+       mapFragment.getMapAsync(this)
     }
 
     // 네이버맵 불러오기가 완료되면 콜백
@@ -238,40 +235,10 @@ class EmergencyMapActivity : AppCompatActivity(), OnMapReadyCallback {
             launcherForPermission.launch(REQUEST_LOCATION_PERMISSIONS)
         } else {
             permissionGrantedMapUiSetting()
-
-            // 사용자 현재 위치 받아오기
-            fusedLocationClient.lastLocation.addOnSuccessListener { location: Location? ->
-                val latitude = location?.latitude ?: 35.1798159
-                val longitude = location?.longitude ?: 129.0750222
-                val coords = "$longitude" + "," + "$latitude"
-
-                viewModel.getuserLocationRegion(coords)
-
-                /*lifecycleScope.launch {
-                    viewModel.getuserLocationRegion(coords)
-                }*/
-
-                // 위치 오버레이의 가시성은 기본적으로 false로 지정되어 있습니다. 가시성을 true로 변경하면 지도에 위치 오버레이가 나타납니다.
-                // 파랑색 점, 현재 위치 표시
-                with(naverMap.locationOverlay) {
-                    isVisible = true
-                    position = LatLng(latitude, longitude)
-                }
-
-                // 카메라 현재 위치로 이동
-                val cameraUpdate = CameraUpdate.scrollTo(
-                    LatLng(
-                        latitude,
-                        longitude
-                    )
-                )
-                naverMap.moveCamera(cameraUpdate)
-            }
         }
         val mapType = intent.getStringExtra("mapType").toString()
         addMaker(mapType)
     }
-
     private fun permissionGrantedMapUiSetting() {
         with(naverMap) {
             setMapType(this)
@@ -286,6 +253,9 @@ class EmergencyMapActivity : AppCompatActivity(), OnMapReadyCallback {
                 when (mode) {
                     "None" -> locationTrackingMode = LocationTrackingMode.Follow
                     "Follow", "NoFollow" -> {
+
+                        setUserLocation()
+
                         // 현재 위치 버튼을 눌렀을 때 카메라가 줌이 너무 작아지는걸 방지
                         if (currentLocation != null) {
                             val latLng = LatLng(currentLocation.latitude, currentLocation.longitude)
@@ -344,6 +314,49 @@ class EmergencyMapActivity : AppCompatActivity(), OnMapReadyCallback {
 
                 // 현위치 버튼
                 isLocationButtonEnabled = true
+            }
+        }
+    }
+
+    private fun setUserLocation(){
+        if (ActivityCompat.checkSelfPermission(
+                this@EmergencyMapActivity,
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ) != PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(
+                this@EmergencyMapActivity,
+                Manifest.permission.ACCESS_COARSE_LOCATION
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            launcherForPermission.launch(REQUEST_LOCATION_PERMISSIONS)
+        } else {
+
+            // 사용자 현재 위치 받아오기
+            fusedLocationClient.lastLocation.addOnSuccessListener { location: Location? ->
+                val latitude = location?.latitude ?: 35.1798159
+                val longitude = location?.longitude ?: 129.0750222
+                val coords = "$longitude" + "," + "$latitude"
+
+                viewModel.getuserLocationRegion(coords)
+
+                /*lifecycleScope.launch {
+                    viewModel.getuserLocationRegion(coords)
+                }*/
+
+                // 위치 오버레이의 가시성은 기본적으로 false로 지정되어 있습니다. 가시성을 true로 변경하면 지도에 위치 오버레이가 나타납니다.
+                // 파랑색 점, 현재 위치 표시
+                with(naverMap.locationOverlay) {
+                    isVisible = true
+                    position = LatLng(latitude, longitude)
+                }
+
+                // 카메라 현재 위치로 이동
+                val cameraUpdate = CameraUpdate.scrollTo(
+                    LatLng(
+                        latitude,
+                        longitude
+                    )
+                )
+                naverMap.moveCamera(cameraUpdate)
             }
         }
     }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/emergency/vm/EmergencyMapViewModel.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/emergency/vm/EmergencyMapViewModel.kt
@@ -24,16 +24,6 @@ class EmergencyMapViewModel(
         addSource(areaDetail) { value = combineAreaAndDetail(area.value, areaDetail.value) }
     }
 
-    /*fun getuserLocationRegion(coords: String){
-        viewModelScope.launch {
-            getUserLocationRegionUseCase(coords).onSuccess {
-                if(it.code == 0){
-                    setArea(it.results[0].area, it.results[0].areaDetail)
-                }
-            }
-        }
-    }*/
-
     fun getuserLocationRegion(coords: String) =
         viewModelScope.launch {
             getUserLocationRegionUseCase(coords).onSuccess {

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/emergency/vm/EmergencyMapViewModel.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/emergency/vm/EmergencyMapViewModel.kt
@@ -4,27 +4,51 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import kr.tekit.lion.daongil.domain.usecase.GetUserLocationRegionUseCase
+import kr.tekit.lion.daongil.domain.usecase.base.onSuccess
 
 class EmergencyMapViewModel(
-
+    private val getUserLocationRegionUseCase: GetUserLocationRegionUseCase
 ) : ViewModel() {
 
-    private val _area = MutableLiveData<String>()
-    val area : LiveData<String> = _area
+    private val _area = MutableLiveData<String?>()
+    val area : LiveData<String?> = _area
 
-    private val _areaDetail = MutableLiveData<String>()
-    val areaDetail: LiveData<String> = _areaDetail
+    private val _areaDetail = MutableLiveData<String?>()
+    val areaDetail: LiveData<String?> = _areaDetail
 
     val combinedArea: MediatorLiveData<String> = MediatorLiveData<String>().apply {
         addSource(area) { value = combineAreaAndDetail(area.value, areaDetail.value) }
         addSource(areaDetail) { value = combineAreaAndDetail(area.value, areaDetail.value) }
     }
 
+    /*fun getuserLocationRegion(coords: String){
+        viewModelScope.launch {
+            getUserLocationRegionUseCase(coords).onSuccess {
+                if(it.code == 0){
+                    setArea(it.results[0].area, it.results[0].areaDetail)
+                }
+            }
+        }
+    }*/
+
+    fun getuserLocationRegion(coords: String) =
+        viewModelScope.launch {
+            getUserLocationRegionUseCase(coords).onSuccess {
+                if (it.code == 0) {
+                    setArea(it.results[0].area, it.results[0].areaDetail)
+                }
+            }
+        }
+
+
     private fun combineAreaAndDetail(area: String?, areaDetail: String?): String {
         return "${area ?: ""} ${areaDetail ?: ""}".trim()
     }
 
-    fun setArea(area: String, areaDetail: String) {
+    fun setArea(area: String?, areaDetail: String?) {
         _area.value = area
         _areaDetail.value = areaDetail
     }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/emergency/vm/EmergencyMapViewModelFactory.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/emergency/vm/EmergencyMapViewModelFactory.kt
@@ -2,13 +2,19 @@ package kr.tekit.lion.daongil.presentation.emergency.vm
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import kr.tekit.lion.daongil.domain.repository.NaverMapRepository
+import kr.tekit.lion.daongil.domain.usecase.GetUserLocationRegionUseCase
 import java.lang.IllegalArgumentException
 
 class EmergencyMapViewModelFactory(): ViewModelProvider.Factory {
 
+    private val getUserLocationRegionUseCase = GetUserLocationRegionUseCase(
+        NaverMapRepository.create()
+    )
+
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(EmergencyMapViewModel::class.java)){
-            return EmergencyMapViewModel() as T
+            return EmergencyMapViewModel(getUserLocationRegionUseCase) as T
         }
         throw IllegalArgumentException("unknown ViewModel class")
     }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/login/fragment/LoginFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/login/fragment/LoginFragment.kt
@@ -45,9 +45,6 @@ class LoginFragment : Fragment(R.layout.fragment_login) {
 
     private fun kakaoLogin() {
         val TAG = "test2345"
-        val apiKey = BuildConfig.KAKAO_API_KEY
-
-        KakaoSdk.init(requireContext(), apiKey)
 
         // 카카오계정으로 로그인 공통 callback 구성
         // 카카오톡으로 로그인 할 수 없어 카카오계정으로 로그인할 경우 사용됨

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/login/fragment/LoginFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/login/fragment/LoginFragment.kt
@@ -46,6 +46,10 @@ class LoginFragment : Fragment(R.layout.fragment_login) {
     private fun kakaoLogin() {
         val TAG = "test2345"
 
+        val apiKey = BuildConfig.KAKAO_API_KEY
+
+        KakaoSdk.init(requireContext(), apiKey)
+
         // 카카오계정으로 로그인 공통 callback 구성
         // 카카오톡으로 로그인 할 수 없어 카카오계정으로 로그인할 경우 사용됨
         val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->


### PR DESCRIPTION
## #️⃣연관된 이슈

- #80 

## 📝작업 내용

- 응급 지원 지도 버튼 텍스트를 현위치와 연결 -> 네이버 지도 api reversegeocoding 사용했습니다
- 지도 현위치 버튼 누르면 다시 갱신시켜주기 (지역 다이얼로그로 수정해서 버튼 텍스트가 현위치와 다르게 바뀌었을때)

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)

https://github.com/APP-Android2/FinalProject-DaOnGil/assets/69308068/7c350ce9-ac1c-4768-baf1-de6e549d7b61



## 💬리뷰 요구사항(선택)

- 네이버 지도 api key를 숨겨서 머지하게될 경우 여러분분들 각각 local.propties에 추가해야할 값이 생깁니다 ! 디코 pr방에 남길테니 다들 추가해서 빌드 돌려주세요~
