### PR TITLE
[#108] 응급실 이용 안내 실시간 메세지 기능 구현

### DIFF
--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/datasource/EmergencyDataSource.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/datasource/EmergencyDataSource.kt
@@ -1,6 +1,7 @@
 package kr.tekit.lion.daongil.data.datasource
 
 import kr.tekit.lion.daongil.data.dto.remote.response.emergency.basic.EmergencyBasicResponse
+import kr.tekit.lion.daongil.data.dto.remote.response.emergency.message.EmergencyMessageResponse
 import kr.tekit.lion.daongil.data.dto.remote.response.emergency.realtime.EmergencyRealtimeResponse
 import kr.tekit.lion.daongil.data.network.service.EmergencyService
 
@@ -13,5 +14,9 @@ class EmergencyDataSource(
 
     suspend fun getEmergencyBasic(HPID: String?) : EmergencyBasicResponse {
         return emergencyService.getEmergencyBasic(HPID)
+    }
+
+    suspend fun getEmergencyMessage(HPID: String?): EmergencyMessageResponse {
+        return emergencyService.getEmergencyMessage(HPID)
     }
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/emergency/message/Body.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/emergency/message/Body.kt
@@ -1,0 +1,11 @@
+package kr.tekit.lion.daongil.data.dto.remote.response.emergency.message
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class Body(
+    val items: Items,
+    val numOfRows: Int,
+    val pageNo: Int,
+    val totalCount: Int
+)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/emergency/message/EmergencyMessageJsonAdapter.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/emergency/message/EmergencyMessageJsonAdapter.kt
@@ -1,0 +1,134 @@
+package kr.tekit.lion.daongil.data.dto.remote.response.emergency.message
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.ToJson
+
+class EmergencyMessageJsonAdapter {
+    @FromJson
+    fun fromJson(reader: JsonReader): Items {
+        val items = mutableListOf<Item>()
+
+        when (reader.peek()) {
+            JsonReader.Token.BEGIN_OBJECT -> {
+                reader.beginObject()
+                while (reader.hasNext()) {
+                    if (reader.nextName() == "item") {
+                        when (reader.peek()) {
+                            JsonReader.Token.BEGIN_OBJECT -> {
+                                items.add(readItem(reader))
+                            }
+                            JsonReader.Token.BEGIN_ARRAY -> {
+                                reader.beginArray()
+                                while (reader.hasNext()) {
+                                    items.add(readItem(reader))
+                                }
+                                reader.endArray()
+                            }
+                            else -> reader.skipValue()
+                        }
+                    } else {
+                        reader.skipValue()
+                    }
+                }
+                reader.endObject()
+            }
+            JsonReader.Token.BEGIN_ARRAY -> {
+                reader.beginArray()
+                while (reader.hasNext()) {
+                    items.add(readItem(reader))
+                }
+                reader.endArray()
+            }
+            JsonReader.Token.STRING -> {
+                reader.nextString() // 빈 문자열 처리
+            }
+            else -> reader.skipValue()
+        }
+
+        return Items(items)
+    }
+
+    @ToJson
+    fun toJson(writer: JsonWriter, value: Items?) {
+        writer.beginObject()
+        writer.name("item")
+        writer.beginArray()
+        value?.item?.forEach { item ->
+            writeItem(writer, item)
+        }
+        writer.endArray()
+        writer.endObject()
+    }
+
+    private fun readItem(reader: JsonReader): Item {
+        var dutyAddr: String? = null
+        var dutyName: String? = null
+        var emcOrgCod: String? = null
+        var hpid: String? = null
+        var rnum: Int? = null
+        var symBlkEndDtm: Long? = null
+        var symBlkMsg: String? = null
+        var symBlkMsgTyp: String? = null
+        var symBlkSttDtm: Long? = null
+        var symOutDspMth: String? = null
+        var symOutDspYon: String? = null
+        var symTypCod: String? = null
+        var symTypCodMag: String? = null
+
+        reader.beginObject()
+        while (reader.hasNext()) {
+            when (reader.nextName()) {
+                "dutyAddr" -> dutyAddr = reader.nextString()
+                "dutyName" -> dutyName = reader.nextString()
+                "emcOrgCod" -> emcOrgCod = reader.nextString()
+                "hpid" -> hpid = reader.nextString()
+                "rnum" -> rnum = reader.nextInt()
+                "symBlkEndDtm" -> symBlkEndDtm = reader.nextLong()
+                "symBlkMsg" -> symBlkMsg = reader.nextString()
+                "symBlkMsgTyp" -> symBlkMsgTyp = reader.nextString()
+                "symBlkSttDtm" -> symBlkSttDtm = reader.nextLong()
+                "symOutDspMth" -> symOutDspMth = reader.nextString()
+                "symOutDspYon" -> symOutDspYon = reader.nextString()
+                "symTypCod" -> symTypCod = reader.nextString()
+                "symTypCodMag" -> symTypCodMag = reader.nextString()
+                else -> reader.skipValue()
+            }
+        }
+        reader.endObject()
+        return Item(
+            dutyAddr ?: "",
+            dutyName ?: "",
+            emcOrgCod ?: "",
+            hpid ?: "",
+            rnum ?: 0,
+            symBlkEndDtm ?: 0L,
+            symBlkMsg ?: "",
+            symBlkMsgTyp ?: "",
+            symBlkSttDtm ?: 0L,
+            symOutDspMth ?: "",
+            symOutDspYon ?: "",
+            symTypCod ?: "",
+            symTypCodMag ?: ""
+        )
+    }
+
+    private fun writeItem(writer: JsonWriter, item: Item) {
+        writer.beginObject()
+        writer.name("dutyAddr").value(item.dutyAddr)
+        writer.name("dutyName").value(item.dutyName)
+        writer.name("emcOrgCod").value(item.emcOrgCod)
+        writer.name("hpid").value(item.hpid)
+        writer.name("rnum").value(item.rnum)
+        writer.name("symBlkEndDtm").value(item.symBlkEndDtm)
+        writer.name("symBlkMsg").value(item.symBlkMsg)
+        writer.name("symBlkMsgTyp").value(item.symBlkMsgTyp)
+        writer.name("symBlkSttDtm").value(item.symBlkSttDtm)
+        writer.name("symOutDspMth").value(item.symOutDspMth)
+        writer.name("symOutDspYon").value(item.symOutDspYon)
+        writer.name("symTypCod").value(item.symTypCod)
+        writer.name("symTypCodMag").value(item.symTypCodMag)
+        writer.endObject()
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/emergency/message/EmergencyMessageResponse.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/emergency/message/EmergencyMessageResponse.kt
@@ -1,0 +1,37 @@
+package kr.tekit.lion.daongil.data.dto.remote.response.emergency.message
+
+import com.squareup.moshi.JsonClass
+import kr.tekit.lion.daongil.domain.model.EmergencyMessageInfo
+
+@JsonClass(generateAdapter = true)
+data class EmergencyMessageResponse(
+    val response: Response
+) {
+    fun toDomainModel(): List<EmergencyMessageInfo> {
+        return this.response.body.items.item
+            .filter { item -> item.symBlkMsgTyp?.contains("응급") ?: false }
+            .map { item ->
+                EmergencyMessageInfo(
+                    emergencyMessage = item.symBlkMsg,
+                    emergencyDate = formatDate(item.symBlkSttDtm.toString())
+                )
+            }
+    }
+
+    fun formatDate(input: String): String {
+        if (input.length != 14) return "-"
+
+        try {
+            val year = input.substring(0, 4)
+            val month = input.substring(4, 6)
+            val day = input.substring(6, 8)
+            val hour = input.substring(8, 10)
+            val minute = input.substring(10, 12)
+            val second = input.substring(12, 14)
+
+            return "$year.$month.$day $hour:$minute:$second"
+        } catch (e: Exception) {
+            return "-"
+        }
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/emergency/message/Header.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/emergency/message/Header.kt
@@ -1,0 +1,9 @@
+package kr.tekit.lion.daongil.data.dto.remote.response.emergency.message
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class Header(
+    val resultCode: String,
+    val resultMsg: String
+)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/emergency/message/Item.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/emergency/message/Item.kt
@@ -1,0 +1,20 @@
+package kr.tekit.lion.daongil.data.dto.remote.response.emergency.message
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class Item(
+    val dutyAddr: String?,
+    val dutyName: String?,
+    val emcOrgCod: String?,
+    val hpid: String?,
+    val rnum: Int?,
+    val symBlkEndDtm: Long?,
+    val symBlkMsg: String?,
+    val symBlkMsgTyp: String?,
+    val symBlkSttDtm: Long?,
+    val symOutDspMth: String?,
+    val symOutDspYon: String?,
+    val symTypCod: String?,
+    val symTypCodMag: String?
+)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/emergency/message/Items.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/emergency/message/Items.kt
@@ -1,0 +1,8 @@
+package kr.tekit.lion.daongil.data.dto.remote.response.emergency.message
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class Items(
+    val item: List<Item>
+)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/emergency/message/Response.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/emergency/message/Response.kt
@@ -1,0 +1,9 @@
+package kr.tekit.lion.daongil.data.dto.remote.response.emergency.message
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class Response(
+    val body: Body,
+    val header: Header
+)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/RetrofitInstance.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/RetrofitInstance.kt
@@ -5,6 +5,7 @@ import com.squareup.moshi.KotlinJsonAdapterFactory
 import com.squareup.moshi.Moshi
 import kr.tekit.lion.daongil.BuildConfig
 import kr.tekit.lion.daongil.data.dto.remote.response.emergency.aed.AedJsonAdapter
+import kr.tekit.lion.daongil.data.dto.remote.response.emergency.message.EmergencyMessageJsonAdapter
 import kr.tekit.lion.daongil.data.dto.remote.response.emergency.realtime.EmergencyRealtimeJsonAdapter
 import kr.tekit.lion.daongil.data.network.service.AedService
 import kr.tekit.lion.daongil.data.network.service.EmergencyService
@@ -84,6 +85,7 @@ object RetrofitInstance {
 
     private val emergencyMoshi = Moshi.Builder()
         .add(EmergencyRealtimeJsonAdapter())
+        .add(EmergencyMessageJsonAdapter())
         .add(KotlinJsonAdapterFactory())
         .build()
 

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/service/EmergencyService.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/service/EmergencyService.kt
@@ -2,6 +2,7 @@ package kr.tekit.lion.daongil.data.network.service
 
 import kr.tekit.lion.daongil.BuildConfig
 import kr.tekit.lion.daongil.data.dto.remote.response.emergency.basic.EmergencyBasicResponse
+import kr.tekit.lion.daongil.data.dto.remote.response.emergency.message.EmergencyMessageResponse
 import kr.tekit.lion.daongil.data.dto.remote.response.emergency.realtime.EmergencyRealtimeResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
@@ -25,4 +26,14 @@ interface EmergencyService {
         @Query("_type") _type: String = "json",
         @Query("serviceKey") serviceKey: String = BuildConfig.EMERGENCY_API_KEY
     ): EmergencyBasicResponse
+
+    // 응급실 실시간 메세지
+    @GET("getEmrrmSrsillDissMsgInqire")
+    suspend fun getEmergencyMessage(
+        @Query("HPID") HPID: String?,
+        @Query("_type") _type: String = "json",
+        @Query("numOfRows") numOfRows: Int = 10000,
+        @Query("serviceKey") serviceKey: String = BuildConfig.EMERGENCY_API_KEY
+    ): EmergencyMessageResponse
+
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/repository/EmergencyRepositoryImpl.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/repository/EmergencyRepositoryImpl.kt
@@ -2,6 +2,7 @@ package kr.tekit.lion.daongil.data.repository
 
 import kr.tekit.lion.daongil.data.datasource.EmergencyDataSource
 import kr.tekit.lion.daongil.domain.model.EmergencyBasicInfo
+import kr.tekit.lion.daongil.domain.model.EmergencyMessageInfo
 import kr.tekit.lion.daongil.domain.model.EmergencyRealtimeInfo
 import kr.tekit.lion.daongil.domain.repository.EmergencyRepository
 
@@ -20,5 +21,9 @@ class EmergencyRepositoryImpl(
         HPID: String?
     ): EmergencyBasicInfo {
         return emergencyDataSource.getEmergencyBasic(HPID).toDomainModel()
+    }
+
+    override suspend fun getEmergencyMessage(HPID: String?): List<EmergencyMessageInfo> {
+        return emergencyDataSource.getEmergencyMessage(HPID).toDomainModel()
     }
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/EmergencyMessage.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/EmergencyMessage.kt
@@ -1,6 +1,0 @@
-package kr.tekit.lion.daongil.domain.model
-
-data class EmergencyMessage(
-    val emergencyMessage: String,
-    val emergencyDate: String
-)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/EmergencyMessageInfo.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/EmergencyMessageInfo.kt
@@ -1,0 +1,6 @@
+package kr.tekit.lion.daongil.domain.model
+
+data class EmergencyMessageInfo(
+    val emergencyMessage: String?,
+    val emergencyDate: String?
+)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/repository/EmergencyRepository.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/repository/EmergencyRepository.kt
@@ -4,6 +4,7 @@ import kr.tekit.lion.daongil.data.datasource.EmergencyDataSource
 import kr.tekit.lion.daongil.data.network.RetrofitInstance
 import kr.tekit.lion.daongil.data.repository.EmergencyRepositoryImpl
 import kr.tekit.lion.daongil.domain.model.EmergencyBasicInfo
+import kr.tekit.lion.daongil.domain.model.EmergencyMessageInfo
 import kr.tekit.lion.daongil.domain.model.EmergencyRealtimeInfo
 
 interface EmergencyRepository {
@@ -11,6 +12,8 @@ interface EmergencyRepository {
     suspend fun getEmergencyRealtime(STAGE1: String?, STAGE2: String?): List<EmergencyRealtimeInfo>
 
     suspend fun getEmergencyBasic(HPID: String?): EmergencyBasicInfo
+
+    suspend fun getEmergencyMessage(HPID: String?):List<EmergencyMessageInfo>
     companion object{
         fun create(): EmergencyRepositoryImpl{
             return EmergencyRepositoryImpl(

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/GetEmergencyMessageUseCase.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/GetEmergencyMessageUseCase.kt
@@ -1,0 +1,15 @@
+package kr.tekit.lion.daongil.domain.usecase
+
+import kr.tekit.lion.daongil.domain.model.EmergencyMessageInfo
+import kr.tekit.lion.daongil.domain.repository.EmergencyRepository
+import kr.tekit.lion.daongil.domain.usecase.base.BaseUseCase
+import kr.tekit.lion.daongil.domain.usecase.base.Result
+
+class GetEmergencyMessageUseCase(
+    private val emergencyRepository: EmergencyRepository
+) : BaseUseCase() {
+    suspend operator fun invoke(HPID: String?): Result<List<EmergencyMessageInfo>> =
+        execute {
+            emergencyRepository.getEmergencyMessage(HPID)
+        }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/emergency/adapter/EmergencyMessageAdapter.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/emergency/adapter/EmergencyMessageAdapter.kt
@@ -4,9 +4,9 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import kr.tekit.lion.daongil.databinding.ItemEmergencyMessageBinding
-import kr.tekit.lion.daongil.domain.model.EmergencyMessage
+import kr.tekit.lion.daongil.domain.model.EmergencyMessageInfo
 
-class EmergencyMessageAdapter(private val emergencyMessageList: List<EmergencyMessage>) :
+class EmergencyMessageAdapter(private val emergencyMessageList: List<EmergencyMessageInfo>) :
     RecyclerView.Adapter<EmergencyMessageAdapter.EmergencyMessageViewHolder>() {
 
     override fun onCreateViewHolder(
@@ -35,7 +35,7 @@ class EmergencyMessageAdapter(private val emergencyMessageList: List<EmergencyMe
 
     class EmergencyMessageViewHolder(private val binding: ItemEmergencyMessageBinding) :
         RecyclerView.ViewHolder(binding.root) {
-        fun bind(item: EmergencyMessage) {
+        fun bind(item: EmergencyMessageInfo) {
             binding.emergencyMessageText.text = item.emergencyMessage
             binding.emergencyMessageDate.text = item.emergencyDate
         }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/emergency/fragment/EmergencyInfoFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/emergency/fragment/EmergencyInfoFragment.kt
@@ -9,31 +9,25 @@ import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.View
 import androidx.core.content.ContextCompat
+import androidx.fragment.app.viewModels
 import kr.tekit.lion.daongil.R
 import kr.tekit.lion.daongil.databinding.FragmentEmergencyInfoBinding
 import kr.tekit.lion.daongil.domain.model.EmergencyBottom
-import kr.tekit.lion.daongil.domain.model.EmergencyMessage
 import kr.tekit.lion.daongil.presentation.emergency.adapter.EmergencyMessageAdapter
+import kr.tekit.lion.daongil.presentation.emergency.vm.EmergencyInfoViewModel
+import kr.tekit.lion.daongil.presentation.emergency.vm.EmergencyInfoViewModelFactory
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 class EmergencyInfoFragment : Fragment(R.layout.fragment_emergency_info) {
 
-    // 더미 data
-    val emergencyMessageList: List<EmergencyMessage> = listOf(
-        EmergencyMessage("소아전담 전문의 부재로 소아환자 진료제한 있으니 사전 연락 필히 요청 부탁드립니다.", "2024.05.31 12:15:01"),
-        EmergencyMessage("안과 평일 야간(18:00~19:00), 주말 해당 과 사정으로 수용 불가", "2024.05.31 12:15:01"),
-        EmergencyMessage("해당 과 사정으로 인해 두부외상 환자 수용 불가", "2024.05.31 12:15:01"),
-        EmergencyMessage("모든 성형외과 진료 불가 (안면외상, 안면 골절, 열상 봉합 등)- 성형외과 의료진 부재", "2024.05.31 12:15:01"),
-        EmergencyMessage("[부인과] 해당 과 사정으로 F/U포함 수용 불가", "2024.05.31 12:15:01"),
-        EmergencyMessage("간담췌외과 인력부족으로 진료제한 있습니다", "2024.05.31 12:15:01"),
-        EmergencyMessage("해당과 인력 부족으로 장중첩/폐색(영유아), 소아 수술 불가합니다.", "2024.05.31 12:15:01"),
-        EmergencyMessage("비뇨기과 인력부족으로 진료 제한 있습니다. 사전연락 부탁드립니다", "2024.05.31 12:15:01"),
-        EmergencyMessage("OS 진료 제한있으니 이송 전 사전연락 부탁드립니다.", "2024.05.31 12:15:01"),
-        EmergencyMessage("신과 인력부족으로 입원 불가하오니 참고하여 주시기 바랍니다.", "2024.05.31 12:15:01")
-    )
-
-    private val emergencyMessageadapter: EmergencyMessageAdapter by lazy {
-        EmergencyMessageAdapter(emergencyMessageList)
+    private val hospitalId by lazy {
+        (requireActivity().intent.getSerializableExtra("data") as EmergencyBottom).emergencyId
     }
+    private val viewModel: EmergencyInfoViewModel by viewModels{ EmergencyInfoViewModelFactory(
+        hospitalId.toString()
+    ) }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -42,6 +36,22 @@ class EmergencyInfoFragment : Fragment(R.layout.fragment_emergency_info) {
         val data = requireActivity().intent.getSerializableExtra("data") as EmergencyBottom
 
         with(binding){
+
+            viewModel.messageList.observe(viewLifecycleOwner) { messageList ->
+
+                if(messageList.size < 1) {
+                    emrDefaultMessage.visibility = View.VISIBLE
+                    emergencyMessageCount.text = messageList.size.toString()
+                    emergencyMessageDate.text = getCurrentFormattedDateTime()
+
+                } else {
+                    emergencyMessageRV.visibility = View.VISIBLE
+                    val emergencyMessageadapter =  EmergencyMessageAdapter(messageList)
+                    emergencyMessageCount.text = messageList.size.toString()
+                    emergencyMessageRV.adapter = emergencyMessageadapter
+                }
+
+            }
 
             emergencyName.text = data.emergencyList?.hospitalName
             emergencyAddress.text = data.emergencyList?.hospitalAddress
@@ -92,13 +102,21 @@ class EmergencyInfoFragment : Fragment(R.layout.fragment_emergency_info) {
                 emergencyKidBedIcon.setBackgroundTintList(colorStateList)
             }
 
-
-            emergencyMessageCount.text = emergencyMessageList.size.toString()
-            emergencyMessageRV.adapter = emergencyMessageadapter
-
             toolbarEmergencyInfo.setNavigationOnClickListener {
                 requireActivity().finish()
             }
         }
     }
+
+    fun getCurrentFormattedDateTime(): String {
+        // 현재 시간 가져오기
+        val currentDateTime = LocalDateTime.now()
+
+        // 원하는 형식 정의
+        val formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm:ss")
+
+        // 포맷팅된 문자열 반환
+        return currentDateTime.format(formatter)
+    }
+
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/emergency/vm/EmergencyInfoViewModel.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/emergency/vm/EmergencyInfoViewModel.kt
@@ -1,0 +1,29 @@
+package kr.tekit.lion.daongil.presentation.emergency.vm
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import kr.tekit.lion.daongil.domain.model.EmergencyMessageInfo
+import kr.tekit.lion.daongil.domain.usecase.GetEmergencyMessageUseCase
+import kr.tekit.lion.daongil.domain.usecase.base.onSuccess
+
+class EmergencyInfoViewModel(
+    private val emergencyMessageUseCase: GetEmergencyMessageUseCase,
+    private val hospitalId: String
+) : ViewModel(){
+    private val _messageList = MutableLiveData<List<EmergencyMessageInfo>>()
+    val messageList: LiveData<List<EmergencyMessageInfo>> = _messageList
+
+    init{
+        getEmergencyMessage()
+    }
+
+    fun getEmergencyMessage() =
+        viewModelScope.launch {
+            emergencyMessageUseCase(hospitalId).onSuccess {
+                _messageList.value = it
+            }
+        }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/emergency/vm/EmergencyInfoViewModelFactory.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/emergency/vm/EmergencyInfoViewModelFactory.kt
@@ -1,0 +1,21 @@
+package kr.tekit.lion.daongil.presentation.emergency.vm
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import kr.tekit.lion.daongil.domain.repository.EmergencyRepository
+import kr.tekit.lion.daongil.domain.usecase.GetEmergencyMessageUseCase
+import java.lang.IllegalArgumentException
+
+class EmergencyInfoViewModelFactory(private val hospitalId: String): ViewModelProvider.Factory {
+
+    private val emergencyMessageUseCase = GetEmergencyMessageUseCase(
+        EmergencyRepository.create()
+    )
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(EmergencyInfoViewModel::class.java)){
+            return EmergencyInfoViewModel(emergencyMessageUseCase, hospitalId) as T
+        }
+        throw IllegalArgumentException("unknown ViewModel class")
+    }
+}

--- a/DaOnGil/app/src/main/res/layout/fragment_emergency_info.xml
+++ b/DaOnGil/app/src/main/res/layout/fragment_emergency_info.xml
@@ -461,6 +461,55 @@
                 app:dividerColor="@color/primary_disabled"
                 app:dividerThickness="2dp" />
 
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/emrDefaultMessage"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_big4"
+                android:backgroundTint="@color/item_background"
+                app:cardCornerRadius="10dp"
+                app:strokeColor="@color/text_tertiary"
+                android:visibility="gone">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="@dimen/margin_big3">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:orientation="horizontal">
+
+                        <ImageView
+                            android:layout_width="40dp"
+                            android:layout_height="40dp"
+                            android:src="@drawable/emergency_message_img" />
+
+                        <TextView
+                            android:id="@+id/emergency_message_text"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="@dimen/margin_big4"
+                            android:fontFamily="@font/pretendard_semibold"
+                            android:text="응급실 이용 안내 메세지가 현재 없습니다."
+                            android:textColor="@color/text_secondary"
+                            android:textSize="@dimen/font_small1"/>
+                    </LinearLayout>
+
+                    <TextView
+                        android:id="@+id/emergency_message_date"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="53dp"
+                        android:fontFamily="@font/pretendard_semibold"
+                        android:textColor="@color/text_secondary"
+                        android:textSize="@dimen/font_small3"/>
+
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/emergencyMessageRV"
                 android:layout_width="match_parent"
@@ -470,6 +519,7 @@
                 android:overScrollMode="never"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 tools:listitem="@layout/item_emergency_message"
+                android:visibility="gone"
                 tools:itemCount="10"/>
 
             <TextView


### PR DESCRIPTION
## #️⃣연관된 이슈

- #108 

## 📝작업 내용

- 응급실 이용 안내 부분 실시간 메세지 api를 이용하여 사용자에게 보여주는 기능 화면을 작업했습니다.

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
<img src="https://github.com/APP-Android2/FinalProject-DaOnGil/assets/69308068/6785b17a-9139-4e10-9f6a-283e0a432fa3" width="350">
<img src="https://github.com/APP-Android2/FinalProject-DaOnGil/assets/69308068/bba7d218-ebef-4b31-85ac-19bf31fddd60" width="350">
<img src="https://github.com/APP-Android2/FinalProject-DaOnGil/assets/69308068/2b023c8b-f7f0-4d92-9e5e-343121322683" width="350">

버튼 누르면 전화로도 연결됩니다...!

## 💬리뷰 요구사항(선택)

- 데이터가 있을때 없을때 다르게 띄워주고 있습니다!
- 아 참고로 아까 pr에서는 얘기 못했는데... 전화도 다 연결해놨어요 !
