### PR TITLE
[Feat] 사용자 프로필 이미지 수정 완료

### DIFF
--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/MyInfoMainFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/MyInfoMainFragment.kt
@@ -2,14 +2,13 @@ package kr.tekit.lion.daongil.presentation.main.fragment
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.google.android.material.snackbar.Snackbar
-import kr.tekit.lion.daongil.BuildConfig
 import kr.tekit.lion.daongil.R
 import kr.tekit.lion.daongil.databinding.FragmentMyInfoMainBinding
 import kr.tekit.lion.daongil.presentation.bookmark.BookmarkActivity
@@ -62,16 +61,19 @@ class MyInfoMainFragment : Fragment(R.layout.fragment_my_info_main), ConfirmDial
         moveBookmark(binding)
         moveMyReview(binding)
         moveDeleteUser(binding)
+        with(binding) {
+            repeatOnViewStarted {
+                viewModel.myInfo.collect {
 
-        repeatOnViewStarted {
-            viewModel.myInfo.collect{
-                with(binding){
                     tvNameOrLogin.text = it.name
                     tvReviewCnt.text = it.reviewNum.toString()
+                    tvRegisteredData.text = "${it.date}일째"
 
-                    Glide.with(requireContext())
+                    Glide.with(binding.imgProfile.context)
                         .load(it.profileImg)
                         .fallback(R.drawable.default_profile)
+                        .diskCacheStrategy(DiskCacheStrategy.NONE)
+                        .skipMemoryCache(true)
                         .into(imgProfile)
                 }
             }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/myinfo/fragment/PersonalInfoModifyFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/myinfo/fragment/PersonalInfoModifyFragment.kt
@@ -19,6 +19,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.google.android.material.snackbar.Snackbar
 import kr.tekit.lion.daongil.R
 import kr.tekit.lion.daongil.databinding.FragmentPersonalInfoModifyBinding
@@ -86,6 +87,8 @@ class PersonalInfoModifyFragment : Fragment(R.layout.fragment_personal_info_modi
             Glide.with(requireContext())
                 .load(viewModel.profileImg.value)
                 .fallback(R.drawable.default_profile)
+                .diskCacheStrategy(DiskCacheStrategy.NONE)
+                .skipMemoryCache(true)
                 .into(imgProfile)
 
             btnModify.setOnClickListener {
@@ -166,15 +169,11 @@ class PersonalInfoModifyFragment : Fragment(R.layout.fragment_personal_info_modi
 
 
     private fun drawImage(view: ImageView, imgUrl: Uri) {
-
-        Log.d("ImgRuestResult", imgUrl.toString())
         Glide.with(requireContext())
             .load(imgUrl)
             .fallback(R.drawable.default_profile)
             .into(view)
         val path = requireContext().toAbsolutePath(imgUrl)
-        Log.d("ImgRuestResult", path.toString())
-
         viewModel.onSelectProfileImage(path)
         viewModel.modifyStateChange()
     }

--- a/DaOnGil/app/src/main/res/layout/fragment_my_info_main.xml
+++ b/DaOnGil/app/src/main/res/layout/fragment_my_info_main.xml
@@ -129,7 +129,7 @@
                         app:layout_constraintTop_toTopOf="@+id/tvReviewCnt" />
 
                     <TextView
-                        android:id="@+id/textViewMyInfoMainRegisterCnt"
+                        android:id="@+id/tv_registered_data"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="@dimen/margin_small2"


### PR DESCRIPTION
## #️⃣연관된 이슈

- #129 

## 📝작업 내용

- 사용자 프로필 사진 수정 완료

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)

https://github.com/APP-Android2/FinalProject-DaOnGil/assets/84930748/c2ed2b15-270f-4bff-a619-d1d3c8fecd05



## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

문제 : 서버에서 호출한 이미지가 변경되지 않음
해결 방법 : Glide Library는 이미지 캐싱으로 메모리를 절약하고 로드를 빠르게 할 수 있다는 점 이 정점이었습니다. 하지만 저희 프로젝트의 경우 이 캐싱 때문에 이미지를 변경해도 기존에 캐시된 이미지가 호출되어 이미지 변경이 이루어지지 않았습니다. 

다음 두 메소드 diskCacheStrategy, skipMemoryCache 을 사용하면 캐싱을 사용하지 않겠다는 의미로 해결 가능합니다.
```
Glide.with(requireContext())
  .load(viewModel.profileImg.value)
  .fallback(R.drawable.default_profile)
  .diskCacheStrategy(DiskCacheStrategy.NONE)
  .skipMemoryCache(true)
  .into(imgProfile)
```

간단한 섬네일 이미지엔 이런 방식이 문제가 되지 않겠지만 용량이 큰 이미지는 이런식으로 사용하면 안될거 같아서 추후 같은 문제가 발생할 경우 다른 접근 방식이 필요해 보입니다 🙂
