### PR TITLE
[#136] 여행일정 메인화면에 공개일정 api 연결

### DIFF
--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/datasource/PlanDataSource.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/datasource/PlanDataSource.kt
@@ -1,0 +1,14 @@
+package kr.tekit.lion.daongil.data.datasource
+
+import kr.tekit.lion.daongil.data.dto.remote.response.plan.OpenPlanListResponse
+import kr.tekit.lion.daongil.data.network.service.PlanService
+
+class PlanDataSource(
+    private val planService: PlanService
+) {
+
+    suspend fun getOpenPlanList(size: Int, page: Int): OpenPlanListResponse {
+        return planService.getOpenPlanList(size, page)
+    }
+
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/plan/Data.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/plan/Data.kt
@@ -1,0 +1,19 @@
+package kr.tekit.lion.daongil.data.dto.remote.response.plan
+
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class Data(
+    @Json(name = "last")
+    val last: Boolean,
+    @Json(name = "openPlanResList")
+    val openPlanResList: List<OpenPlanRes>,
+    @Json(name = "pageNo")
+    val pageNo: Int,
+    @Json(name = "pageSize")
+    val pageSize: Int,
+    @Json(name = "totalPages")
+    val totalPages: Int
+)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/plan/OpenPlanListResponse.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/plan/OpenPlanListResponse.kt
@@ -7,18 +7,16 @@ import kr.tekit.lion.daongil.domain.model.OpenPlanInfo
 
 @JsonClass(generateAdapter = true)
 data class OpenPlanListResponse(
-    val last: Boolean,
-    val openPlanResList: List<OpenPlanRes>,
-    val pageNo: Int,
-    val pageSize: Int,
-    val totalPages: Int
+    val code: Int,
+    val data: Data,
+    val message: String
 ) {
     fun toDomainModel() : OpenPlan {
         return OpenPlan(
-            last = this.last,
-            pageNo = this.pageNo,
-            totalPages = this.totalPages,
-            openPlanList = this.openPlanResList.map {
+            last = this.data.last,
+            pageNo = this.data.pageNo,
+            totalPages = this.data.totalPages,
+            openPlanList = this.data.openPlanResList.map {
                 OpenPlanInfo(
                     date = it.date,
                     imageUrl = it.imageUrl,

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/plan/OpenPlanListResponse.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/plan/OpenPlanListResponse.kt
@@ -1,0 +1,34 @@
+package kr.tekit.lion.daongil.data.dto.remote.response.plan
+
+
+import com.squareup.moshi.JsonClass
+import kr.tekit.lion.daongil.domain.model.OpenPlan
+import kr.tekit.lion.daongil.domain.model.OpenPlanInfo
+
+@JsonClass(generateAdapter = true)
+data class OpenPlanListResponse(
+    val last: Boolean,
+    val openPlanResList: List<OpenPlanRes>,
+    val pageNo: Int,
+    val pageSize: Int,
+    val totalPages: Int
+) {
+    fun toDomainModel() : OpenPlan {
+        return OpenPlan(
+            last = this.last,
+            pageNo = this.pageNo,
+            totalPages = this.totalPages,
+            openPlanList = this.openPlanResList.map {
+                OpenPlanInfo(
+                    date = it.date,
+                    imageUrl = it.imageUrl,
+                    memberId = it.memberId,
+                    memberImageUrl = it.memberImageUrl,
+                    memberNickname = it.memberNickname,
+                    planId = it.planId,
+                    title = it.title
+                )
+            }
+        )
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/plan/OpenPlanRes.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/plan/OpenPlanRes.kt
@@ -1,0 +1,16 @@
+package kr.tekit.lion.daongil.data.dto.remote.response.plan
+
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class OpenPlanRes(
+    val date: String,
+    val imageUrl: String,
+    val memberId: Int,
+    val memberImageUrl: String,
+    val memberNickname: String,
+    val planId: Int,
+    val title: String
+)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/service/PlanService.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/service/PlanService.kt
@@ -1,0 +1,15 @@
+package kr.tekit.lion.daongil.data.network.service
+
+import kr.tekit.lion.daongil.data.dto.remote.response.plan.OpenPlanListResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface PlanService {
+
+    // 공개 일정 정보
+    @GET("plan/open")
+    suspend fun getOpenPlanList(
+        @Query("size") size: Int,
+        @Query("page") page: Int
+    ): OpenPlanListResponse
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/service/PlanService.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/service/PlanService.kt
@@ -1,8 +1,10 @@
 package kr.tekit.lion.daongil.data.network.service
 
 import kr.tekit.lion.daongil.data.dto.remote.response.plan.OpenPlanListResponse
+import kr.tekit.lion.daongil.data.network.AuthType
 import retrofit2.http.GET
 import retrofit2.http.Query
+import retrofit2.http.Tag
 
 interface PlanService {
 
@@ -10,6 +12,7 @@ interface PlanService {
     @GET("plan/open")
     suspend fun getOpenPlanList(
         @Query("size") size: Int,
-        @Query("page") page: Int
+        @Query("page") page: Int,
+        @Tag authType: AuthType = AuthType.NO_AUTH,
     ): OpenPlanListResponse
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/repository/PlanRepositoryImpl.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/repository/PlanRepositoryImpl.kt
@@ -1,0 +1,13 @@
+package kr.tekit.lion.daongil.data.repository
+
+import kr.tekit.lion.daongil.data.datasource.PlanDataSource
+import kr.tekit.lion.daongil.domain.model.OpenPlan
+import kr.tekit.lion.daongil.domain.repository.PlanRepository
+
+class PlanRepositoryImpl(
+    private val planDataSource: PlanDataSource
+) : PlanRepository {
+    override suspend fun getOpenPlanList(size: Int, page: Int): OpenPlan {
+        return planDataSource.getOpenPlanList(size, page).toDomainModel()
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/OpenPlan.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/OpenPlan.kt
@@ -1,0 +1,9 @@
+package kr.tekit.lion.daongil.domain.model
+
+
+data class OpenPlan(
+    val last: Boolean,
+    val openPlanList: List<OpenPlanInfo>,
+    val pageNo: Int,
+    val totalPages: Int
+)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/OpenPlanInfo.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/OpenPlanInfo.kt
@@ -1,0 +1,11 @@
+package kr.tekit.lion.daongil.domain.model
+
+data class OpenPlanInfo (
+    val date: String,
+    val imageUrl: String,
+    val memberId: Int,
+    val memberImageUrl: String,
+    val memberNickname: String,
+    val planId: Int,
+    val title: String
+)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/repository/PlanRepository.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/repository/PlanRepository.kt
@@ -1,0 +1,21 @@
+package kr.tekit.lion.daongil.domain.repository
+
+import kr.tekit.lion.daongil.data.datasource.PlanDataSource
+import kr.tekit.lion.daongil.data.network.RetrofitInstance
+import kr.tekit.lion.daongil.data.network.service.PlanService
+import kr.tekit.lion.daongil.data.repository.PlanRepositoryImpl
+import kr.tekit.lion.daongil.domain.model.OpenPlan
+
+interface PlanRepository {
+    suspend fun getOpenPlanList(size: Int, page: Int): OpenPlan
+
+    companion object{
+        fun create(): PlanRepositoryImpl{
+            return PlanRepositoryImpl(
+                PlanDataSource(
+                    RetrofitInstance.serviceProvider(PlanService::class.java)
+                )
+            )
+        }
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/GetOpenPlanListUseCase.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/GetOpenPlanListUseCase.kt
@@ -1,0 +1,15 @@
+package kr.tekit.lion.daongil.domain.usecase
+
+import kr.tekit.lion.daongil.domain.model.OpenPlan
+import kr.tekit.lion.daongil.domain.repository.PlanRepository
+import kr.tekit.lion.daongil.domain.usecase.base.BaseUseCase
+import kr.tekit.lion.daongil.domain.usecase.base.Result
+
+class GetOpenPlanListUseCase(
+    private val planRepository: PlanRepository
+) : BaseUseCase() {
+
+    suspend operator fun invoke(size: Int, page: Int): Result<OpenPlan> = execute {
+        planRepository.getOpenPlanList(size, page)
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/ext/GlideExt.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/ext/GlideExt.kt
@@ -1,0 +1,15 @@
+package kr.tekit.lion.daongil.presentation.ext
+
+import android.content.Context
+import android.widget.ImageView
+import com.bumptech.glide.Glide
+import kr.tekit.lion.daongil.R
+
+fun Context.setImage(imageView: ImageView, url: String?) {
+
+    Glide.with(this).load(url)
+        .placeholder(R.drawable.empty_view_small) // 로딩 중일 때
+        .error(R.drawable.empty_view_small) // 오류 발생 시
+        .into(imageView)
+
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/adapter/SchedulePublicAdapter.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/adapter/SchedulePublicAdapter.kt
@@ -8,20 +8,31 @@ import kr.tekit.lion.daongil.databinding.RowSchedulePublicBinding
 import kr.tekit.lion.daongil.domain.model.OpenPlanInfo
 import kr.tekit.lion.daongil.presentation.ext.setImage
 
-class SchedulePublicAdapter :
+class SchedulePublicAdapter(
+    private val itemClickListener: (Int) -> Unit
+) :
     RecyclerView.Adapter<SchedulePublicAdapter.SchedulePublicViewHolder>() {
 
     private var items: MutableList<OpenPlanInfo> = mutableListOf()
 
-    fun addItems(newItems: List<OpenPlanInfo>){
+    fun addItems(newItems: List<OpenPlanInfo>) {
         items = newItems.toMutableList()
         notifyDataSetChanged()
     }
 
-    class SchedulePublicViewHolder(private val binding: RowSchedulePublicBinding) :
+    class SchedulePublicViewHolder(
+        private val binding: RowSchedulePublicBinding,
+        private val itemClickListener: (Int) -> Unit
+    ) :
         RecyclerView.ViewHolder(binding.root) {
+        init {
+            binding.root.setOnClickListener {
+                itemClickListener(adapterPosition)
+            }
+        }
+
         fun bind(item: OpenPlanInfo) {
-            with(binding){
+            with(binding) {
                 textViewRowSchedulePublicPeriod.text = item.date
                 textViewRowScheduleName.text = item.title
                 textViewRowSchedulePublicNickname.text = item.memberNickname
@@ -35,7 +46,10 @@ class SchedulePublicAdapter :
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SchedulePublicViewHolder {
         val inflater = LayoutInflater.from(parent.context)
-        return SchedulePublicViewHolder(RowSchedulePublicBinding.inflate(inflater, parent, false))
+        return SchedulePublicViewHolder(
+            RowSchedulePublicBinding.inflate(inflater, parent, false),
+            itemClickListener
+        )
     }
 
     override fun onBindViewHolder(holder: SchedulePublicViewHolder, position: Int) {

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/adapter/SchedulePublicAdapter.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/adapter/SchedulePublicAdapter.kt
@@ -3,16 +3,34 @@ package kr.tekit.lion.daongil.presentation.main.adapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
 import kr.tekit.lion.daongil.databinding.RowSchedulePublicBinding
+import kr.tekit.lion.daongil.domain.model.OpenPlanInfo
+import kr.tekit.lion.daongil.presentation.ext.setImage
 
 class SchedulePublicAdapter :
     RecyclerView.Adapter<SchedulePublicAdapter.SchedulePublicViewHolder>() {
 
+    private var items: MutableList<OpenPlanInfo> = mutableListOf()
+
+    fun addItems(newItems: List<OpenPlanInfo>){
+        items = newItems.toMutableList()
+        notifyDataSetChanged()
+    }
+
     class SchedulePublicViewHolder(private val binding: RowSchedulePublicBinding) :
         RecyclerView.ViewHolder(binding.root) {
-            fun bind(){
-                // data와 view연결
+        fun bind(item: OpenPlanInfo) {
+            with(binding){
+                textViewRowSchedulePublicPeriod.text = item.date
+                textViewRowScheduleName.text = item.title
+                textViewRowSchedulePublicNickname.text = item.memberNickname
+
+                root.context.setImage(imageViewRowSchedulePublicThumb, item.imageUrl)
+                root.context.setImage(imageViewRowSchedulePublicProfile, item.memberImageUrl)
             }
+
+        }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SchedulePublicViewHolder {
@@ -21,10 +39,10 @@ class SchedulePublicAdapter :
     }
 
     override fun onBindViewHolder(holder: SchedulePublicViewHolder, position: Int) {
-        holder.bind()
+        holder.bind(items[position])
     }
 
     override fun getItemCount(): Int {
-        return 5
+        return items.size
     }
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/ScheduleMainFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/ScheduleMainFragment.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.View
+import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import kr.tekit.lion.daongil.R
 import kr.tekit.lion.daongil.databinding.FragmentScheduleMainBinding
@@ -12,6 +13,8 @@ import kr.tekit.lion.daongil.presentation.main.customview.ConfirmDialog
 import kr.tekit.lion.daongil.presentation.main.customview.ConfirmDialogInterface
 import kr.tekit.lion.daongil.presentation.main.adapter.ScheduleMyAdapter
 import kr.tekit.lion.daongil.presentation.main.adapter.SchedulePublicAdapter
+import kr.tekit.lion.daongil.presentation.main.vm.ScheduleMainViewModel
+import kr.tekit.lion.daongil.presentation.main.vm.ScheduleMainViewModelFactory
 import kr.tekit.lion.daongil.presentation.myschedule.MyScheduleActivity
 import kr.tekit.lion.daongil.presentation.publicschedule.PublicScheduleActivity
 import kr.tekit.lion.daongil.presentation.schedule.ScheduleActivity
@@ -21,6 +24,8 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main), ConfirmD
     ScheduleMyAdapter.OnScheduleMainItemClickListener {
 
     private var isUser = true
+
+    private val viewModel: ScheduleMainViewModel by viewModels { ScheduleMainViewModelFactory() }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -46,14 +51,19 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main), ConfirmD
 
 
     private fun settingRecyclerView(binding : FragmentScheduleMainBinding, context: Context){
-        binding.apply {
+
+        with(binding){
             recyclerViewMySchedule.apply {
                 adapter = ScheduleMyAdapter(this@ScheduleMainFragment)
                 layoutManager = LinearLayoutManager(context)
             }
 
             recyclerViewPublicSchedule.apply {
-                adapter = SchedulePublicAdapter()
+                val schedulePublicAdapter = SchedulePublicAdapter()
+                viewModel.openPlanList.observe(viewLifecycleOwner) {
+                    schedulePublicAdapter.addItems(it)
+                }
+                    adapter = schedulePublicAdapter
                 layoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
             }
         }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/ScheduleMainFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/ScheduleMainFragment.kt
@@ -3,6 +3,7 @@ package kr.tekit.lion.daongil.presentation.main.fragment
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.View
 import androidx.fragment.app.viewModels
@@ -59,11 +60,16 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main), ConfirmD
             }
 
             recyclerViewPublicSchedule.apply {
-                val schedulePublicAdapter = SchedulePublicAdapter()
                 viewModel.openPlanList.observe(viewLifecycleOwner) {
+                    val schedulePublicAdapter = SchedulePublicAdapter(
+                        itemClickListener = {position ->
+                            // 공개 일정 상세보기 페이지로 이동
+                            // onScheduleMainItemClick(it[position].planId)
+                        }
+                    )
                     schedulePublicAdapter.addItems(it)
-                }
                     adapter = schedulePublicAdapter
+                }
                 layoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
             }
         }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/vm/ScheduleMainViewModel.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/vm/ScheduleMainViewModel.kt
@@ -1,0 +1,30 @@
+package kr.tekit.lion.daongil.presentation.main.vm
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import kr.tekit.lion.daongil.domain.model.OpenPlanInfo
+import kr.tekit.lion.daongil.domain.usecase.GetOpenPlanListUseCase
+import kr.tekit.lion.daongil.domain.usecase.base.onSuccess
+
+class ScheduleMainViewModel(
+    private val getOpenPlanListUseCase: GetOpenPlanListUseCase
+): ViewModel() {
+
+    private val _openPlanList = MutableLiveData<List<OpenPlanInfo>>()
+    val openPlanList : LiveData<List<OpenPlanInfo>> = _openPlanList
+
+    init {
+        getOpenPlanList(5, 0)
+    }
+
+    fun getOpenPlanList(size: Int, page: Int) =
+        viewModelScope.launch {
+            getOpenPlanListUseCase(size, page).onSuccess {
+                _openPlanList.value = it.openPlanList
+            }
+        }
+
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/vm/ScheduleMainViewModelFactory.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/vm/ScheduleMainViewModelFactory.kt
@@ -1,0 +1,18 @@
+package kr.tekit.lion.daongil.presentation.main.vm
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import kr.tekit.lion.daongil.domain.repository.PlanRepository
+import kr.tekit.lion.daongil.domain.usecase.GetOpenPlanListUseCase
+
+class ScheduleMainViewModelFactory(): ViewModelProvider.Factory {
+
+    private val getOpenPlanListUseCase = GetOpenPlanListUseCase(PlanRepository.create())
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(ScheduleMainViewModel::class.java)) {
+            return ScheduleMainViewModel(getOpenPlanListUseCase) as T
+        }
+        throw IllegalArgumentException("unknown ViewModel class")
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #136 

## 📝작업 내용

- 여행일정 메인화면에 공개일정 API 연결했습니다.

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
<img src="https://github.com/APP-Android2/FinalProject-DaOnGil/assets/69308068/4347af05-fd08-4de8-b9ff-242483e8aea3" width="350">


## 💬리뷰 요구사항(선택)

- 아직 공개 일정 더보기는 구현하지 않은 상황입니다! 
