### PR TITLE
[#147] 마이페이지 메인화면 비회원/회원 UI 수정

### DIFF
--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/MyInfoMainFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/MyInfoMainFragment.kt
@@ -15,6 +15,7 @@ import kr.tekit.lion.daongil.presentation.bookmark.BookmarkActivity
 import kr.tekit.lion.daongil.presentation.concerntype.ConcernTypeActivity
 import kr.tekit.lion.daongil.presentation.ext.repeatOnViewStarted
 import kr.tekit.lion.daongil.presentation.login.LogInState
+import kr.tekit.lion.daongil.presentation.login.LoginActivity
 import kr.tekit.lion.daongil.presentation.main.customview.ConfirmDialog
 import kr.tekit.lion.daongil.presentation.main.customview.ConfirmDialogInterface
 import kr.tekit.lion.daongil.presentation.main.vm.MyInfoMainViewModel
@@ -67,7 +68,7 @@ class MyInfoMainFragment : Fragment(R.layout.fragment_my_info_main), ConfirmDial
 
                     tvNameOrLogin.text = it.name
                     tvReviewCnt.text = it.reviewNum.toString()
-                    tvRegisteredData.text = "${it.date}일째"
+                    tvRegisteredData.text = "${it.date + 1}일째"
 
                     Glide.with(binding.imgProfile.context)
                         .load(it.profileImg)
@@ -83,11 +84,14 @@ class MyInfoMainFragment : Fragment(R.layout.fragment_my_info_main), ConfirmDial
     private fun setUiLoginRequiredState(binding: FragmentMyInfoMainBinding) {
         with(binding) {
             userContainer.visibility = View.GONE
-            tvReview.text = "로그인 하러가기"
+            tvReview.text = getString(R.string.text_NameOrLogin)
             tvReviewCnt.visibility = View.GONE
             tvUserNameTitle.visibility = View.GONE
-            tvNameOrLogin.text = "로그인 해주세요"
-            btnLoginOrUpdate.setOnClickListener {
+            textViewMyInfoMainRegister.visibility = View.GONE
+            tvNameOrLogin.text = getString(R.string.text_myInfo_Review)
+            layoutProfile.setOnClickListener {
+                val intent = Intent(requireActivity(), LoginActivity::class.java)
+                startActivity(intent)
             }
         }
     }

--- a/DaOnGil/app/src/main/res/values/strings.xml
+++ b/DaOnGil/app/src/main/res/values/strings.xml
@@ -147,4 +147,6 @@
     <string name="text_place_bookmark">북마크한 장소가 없습니다.\n가고 싶은 장소를 추가해보세요!</string>
     <string name="text_plan_bookmark">북마크한 일정이 없습니다.\n관심 있는 일정을 추가해보세요!</string>
 
+    <string name="text_NameOrLogin">아직 정보가 없어요!</string>
+    <string name="text_myInfo_Review">로그인을 진행해주세요</string>
 </resources>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #147 

## 📝작업 내용

- 마이페이지 메인화면에서 로그인이 안되어있을 경우
- 마이페이지 메인화면에서 가입 일자 수 수정
 - 로그인 안되어있을 경우 위에 프로필 레이아웃 부분 클릭시 로그인 화면으로 이동

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
<img src="https://github.com/APP-Android2/FinalProject-DaOnGil/assets/69308068/4b4ead04-42de-4925-9416-2b0bb993c4dbc" width="350">
<img src="https://github.com/APP-Android2/FinalProject-DaOnGil/assets/69308068/0ea1ab68-c079-44a3-9bfa-f76992541137" width="350">



## 💬리뷰 요구사항(선택)

- UI는 피그마처럼 수정했고, 로그인 안되어있을시 프로필 layout 클릭하면 로그인 화면으로 연결해놓았습니다 ~
