### PR TITLE
[#158] 관광지 상세보기 게스트 api 구현

### DIFF
--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/datasource/PlaceDetailInfoGuestDataSource.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/datasource/PlaceDetailInfoGuestDataSource.kt
@@ -1,0 +1,12 @@
+package kr.tekit.lion.daongil.data.datasource
+
+import kr.tekit.lion.daongil.data.dto.remote.response.detailPlaceGuest.DetailPlaceGuestResponse
+import kr.tekit.lion.daongil.data.network.service.PlaceService
+
+class PlaceDetailInfoGuestDataSource(
+    private val placeService: PlaceService
+) {
+    suspend fun getPlaceDetailInfoGuest(placeId: Long):DetailPlaceGuestResponse{
+        return placeService.getPlaceDetailInfoGuest(placeId)
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/detailPlaceGuest/Data.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/detailPlaceGuest/Data.kt
@@ -1,0 +1,22 @@
+package kr.tekit.lion.daongil.data.dto.remote.response.detailPlaceGuest
+
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class Data(
+    val address: String,
+    val bookmarkNum: Int,
+    val category: String,
+    val disability: List<Int>,
+    @Json(name = "imgae")
+    val image: String,
+    val mapX: String,
+    val mapY: String,
+    val name: String,
+    val overview: String,
+    val placeId: Int,
+    val reviewList: List<ReviewGuestRes>?,
+    val subDisability: List<String>
+)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/detailPlaceGuest/DetailPlaceGuestResponse.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/detailPlaceGuest/DetailPlaceGuestResponse.kt
@@ -1,0 +1,40 @@
+package kr.tekit.lion.daongil.data.dto.remote.response.detailPlaceGuest
+
+import com.squareup.moshi.JsonClass
+import kr.tekit.lion.daongil.domain.model.PlaceDetailInfoGuest
+import kr.tekit.lion.daongil.domain.model.Review
+
+@JsonClass(generateAdapter = true)
+data class DetailPlaceGuestResponse(
+    val code: Int,
+    val data: Data,
+    val message: String
+) {
+    fun toDomainModel(): PlaceDetailInfoGuest{
+        return PlaceDetailInfoGuest(
+            code = code,
+            address = data.address,
+            bookmarkNum = data.bookmarkNum,
+            category = data.category,
+            disability = data.disability,
+            image = data.image,
+            latitude = data.mapX,
+            longitude = data.mapY,
+            name = data.name,
+            overview = data.overview,
+            placeId = data.placeId,
+            reviewList = data.reviewList?.map {
+                Review(
+                    reviewImg = it.reviewImg,
+                    nickname = it.nickname,
+                    profileImg = it.profileImg,
+                    content = it.content,
+                    reviewId = it.reviewId,
+                    grade = it.grade,
+                    date = it.date
+                )
+            },
+            subDisability = data.subDisability
+        )
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/detailPlaceGuest/ReviewGuestRes.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/detailPlaceGuest/ReviewGuestRes.kt
@@ -1,0 +1,15 @@
+package kr.tekit.lion.daongil.data.dto.remote.response.detailPlaceGuest
+
+import com.squareup.moshi.JsonClass
+import java.time.LocalDateTime
+
+@JsonClass(generateAdapter = true)
+data class ReviewGuestRes (
+    val reviewId: Long,
+    val nickname : String,
+    val profileImg : String,
+    val content : String,
+    val reviewImg : String,
+    val grade : Float,
+    val date : LocalDateTime
+)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/detailplace/Data.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/detailplace/Data.kt
@@ -1,5 +1,6 @@
 package kr.tekit.lion.daongil.data.dto.remote.response.detailplace
 
+import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
@@ -8,6 +9,7 @@ data class Data(
     val bookmarkNum: Int,
     val category: String,
     val disability: List<Int>,
+    @Json(name = "imgae")
     val image: String?,
     val isMark: Boolean,
     val mapX: String,

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/service/PlaceService.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/service/PlaceService.kt
@@ -1,10 +1,13 @@
 package kr.tekit.lion.daongil.data.network.service
 
+import kr.tekit.lion.daongil.data.dto.remote.response.detailPlaceGuest.DetailPlaceGuestResponse
 import kr.tekit.lion.daongil.data.dto.remote.response.detailplace.DetailPlaceResponse
 import kr.tekit.lion.daongil.data.dto.remote.response.mainplace.MainPlaceResponse
+import kr.tekit.lion.daongil.data.network.AuthType
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
+import retrofit2.http.Tag
 
 interface PlaceService {
     @GET("place/{placeId}")
@@ -17,4 +20,10 @@ interface PlaceService {
         @Query("areacode") areacode : String,
         @Query("sigungucode") sigungucode : String
     ): MainPlaceResponse
+
+    @GET("place/guest/{placeId}")
+    suspend fun getPlaceDetailInfoGuest(
+        @Path("placeId") placeId: Long,
+        @Tag authType: AuthType = AuthType.NO_AUTH
+    ): DetailPlaceGuestResponse
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/repository/PlaceDetailInfoGuestRepositoryImpl.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/repository/PlaceDetailInfoGuestRepositoryImpl.kt
@@ -1,0 +1,14 @@
+package kr.tekit.lion.daongil.data.repository
+
+import kr.tekit.lion.daongil.data.datasource.PlaceDetailInfoGuestDataSource
+import kr.tekit.lion.daongil.domain.model.PlaceDetailInfoGuest
+import kr.tekit.lion.daongil.domain.repository.PlaceDetailInfoGuestRepository
+
+class PlaceDetailInfoGuestRepositoryImpl(
+    private val placeDetailInfoGuestDataSource: PlaceDetailInfoGuestDataSource
+): PlaceDetailInfoGuestRepository {
+
+    override suspend fun getPlaceDetailInfoGuest(placeId: Long): PlaceDetailInfoGuest {
+        return placeDetailInfoGuestDataSource.getPlaceDetailInfoGuest(placeId).toDomainModel()
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/PlaceDetailInfo.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/PlaceDetailInfo.kt
@@ -3,11 +3,11 @@ package kr.tekit.lion.daongil.domain.model
 data class PlaceDetailInfo (
     val code: Int,
     val address: String,
-    val bookmarkNum: Int,
+    var bookmarkNum: Int,
     val category: String,
     val disability: List<Int>,
     val image: String?,
-    val isMark: Boolean,
+    var isMark: Boolean,
     val latitude: String,
     val longitude: String,
     val name: String,

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/PlaceDetailInfoGuest.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/PlaceDetailInfoGuest.kt
@@ -1,0 +1,17 @@
+package kr.tekit.lion.daongil.domain.model
+
+data class PlaceDetailInfoGuest (
+    val code: Int,
+    val address: String,
+    val bookmarkNum: Int,
+    val category: String,
+    val disability: List<Int>,
+    val image: String?,
+    val latitude: String,
+    val longitude: String,
+    val name: String,
+    val overview: String,
+    val placeId: Int,
+    val reviewList: List<Review>?,
+    val subDisability: List<String>
+)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/repository/PlaceDetailInfoGuestRepository.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/repository/PlaceDetailInfoGuestRepository.kt
@@ -1,0 +1,21 @@
+package kr.tekit.lion.daongil.domain.repository
+
+import kr.tekit.lion.daongil.data.datasource.PlaceDetailInfoGuestDataSource
+import kr.tekit.lion.daongil.data.network.RetrofitInstance
+import kr.tekit.lion.daongil.data.network.service.PlaceService
+import kr.tekit.lion.daongil.data.repository.PlaceDetailInfoGuestRepositoryImpl
+import kr.tekit.lion.daongil.domain.model.PlaceDetailInfoGuest
+
+interface PlaceDetailInfoGuestRepository {
+    suspend fun getPlaceDetailInfoGuest(placeId: Long): PlaceDetailInfoGuest
+
+    companion object{
+        fun create(): PlaceDetailInfoGuestRepositoryImpl{
+            return PlaceDetailInfoGuestRepositoryImpl(
+                PlaceDetailInfoGuestDataSource(
+                    RetrofitInstance.serviceProvider(PlaceService::class.java)
+                )
+            )
+        }
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/GetPlaceDetailInfoGuestUseCase.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/GetPlaceDetailInfoGuestUseCase.kt
@@ -1,0 +1,14 @@
+package kr.tekit.lion.daongil.domain.usecase
+
+import kr.tekit.lion.daongil.domain.model.PlaceDetailInfoGuest
+import kr.tekit.lion.daongil.domain.repository.PlaceDetailInfoGuestRepository
+import kr.tekit.lion.daongil.domain.usecase.base.BaseUseCase
+import kr.tekit.lion.daongil.domain.usecase.base.Result
+
+class GetPlaceDetailInfoGuestUseCase (
+    private val placeDetailInfoGuestRepository: PlaceDetailInfoGuestRepository
+): BaseUseCase() {
+    suspend operator fun invoke(placeId: Long): Result<PlaceDetailInfoGuest> = execute {
+        placeDetailInfoGuestRepository.getPlaceDetailInfoGuest(placeId)
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/home/DetailActivity.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/home/DetailActivity.kt
@@ -34,7 +34,7 @@ import kr.tekit.lion.daongil.presentation.home.vm.DetailViewModelFactory
 import kr.tekit.lion.daongil.presentation.login.LogInState
 
 class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
-    private val viewModel : DetailViewModel by viewModels { DetailViewModelFactory(applicationContext) }
+    private val viewModel : DetailViewModel by viewModels { DetailViewModelFactory(this) }
     private val binding : ActivityDetailBinding by lazy {
         ActivityDetailBinding.inflate(layoutInflater)
     }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/home/vm/DetailViewModel.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/home/vm/DetailViewModel.kt
@@ -5,17 +5,46 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kr.tekit.lion.daongil.domain.model.PlaceDetailInfo
+import kr.tekit.lion.daongil.domain.model.PlaceDetailInfoGuest
+import kr.tekit.lion.daongil.domain.repository.AuthRepository
+import kr.tekit.lion.daongil.domain.usecase.GetPlaceDetailInfoGuestUseCase
 import kr.tekit.lion.daongil.domain.usecase.GetPlaceDetailInfoUseCase
+import kr.tekit.lion.daongil.domain.usecase.UpdatePlaceBookmarkUseCase
 import kr.tekit.lion.daongil.domain.usecase.base.onError
 import kr.tekit.lion.daongil.domain.usecase.base.onSuccess
+import kr.tekit.lion.daongil.presentation.login.LogInState
 
 class DetailViewModel(
-    private val getPlaceDetailInfoUseCase: GetPlaceDetailInfoUseCase
+    private val authRepository: AuthRepository,
+    private val getPlaceDetailInfoUseCase: GetPlaceDetailInfoUseCase,
+    private val getPlaceDetailInfoGuestUseCase : GetPlaceDetailInfoGuestUseCase,
+    private val updateBookmarkUseCase: UpdatePlaceBookmarkUseCase
 ) : ViewModel() {
+    private val _loginState = MutableStateFlow<LogInState>(LogInState.Checking)
+    val loginState = _loginState.asStateFlow()
+
     private val _detailPlaceInfo = MutableLiveData<PlaceDetailInfo>()
     val detailPlaceInfo : LiveData<PlaceDetailInfo> = _detailPlaceInfo
+
+    private val _detailPlaceInfoGuest = MutableLiveData<PlaceDetailInfoGuest>()
+    val detailPlaceInfoGuest : LiveData<PlaceDetailInfoGuest> = _detailPlaceInfoGuest
+
+    init {
+        viewModelScope.launch {
+            checkLoginState()
+        }
+    }
+
+    private suspend fun checkLoginState(){
+        authRepository.loggedIn.collect{ isLoggedIn ->
+            if (isLoggedIn) _loginState.value = LogInState.LoggedIn
+            else _loginState.value = LogInState.LoginRequired
+        }
+    }
 
     fun getDetailPlace(placeId: Long) = viewModelScope.launch {
         getPlaceDetailInfoUseCase(placeId).onSuccess {
@@ -23,6 +52,23 @@ class DetailViewModel(
             _detailPlaceInfo.value = it
         }.onError {
             Log.d("getDetailPlace", it.toString())
+        }
+    }
+
+    fun getDetailPlaceGuest(placeId: Long) = viewModelScope.launch {
+        getPlaceDetailInfoGuestUseCase(placeId).onSuccess {
+            Log.d("getDetailPlaceGuest", it.toString())
+            _detailPlaceInfoGuest.value = it
+        }.onError {
+            Log.d("getDetailPlaceGuest", it.toString())
+        }
+    }
+
+    fun updateDetailPlaceBookmark(placeId: Long) = viewModelScope.launch {
+        updateBookmarkUseCase(placeId).onSuccess {
+            Log.d("updateDetailPlaceBookmark", it.toString())
+        }.onError {
+            Log.d("updateDetailPlaceBookmark", it.toString())
         }
     }
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/home/vm/DetailViewModelFactory.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/home/vm/DetailViewModelFactory.kt
@@ -1,19 +1,33 @@
 package kr.tekit.lion.daongil.presentation.home.vm
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import kr.tekit.lion.daongil.domain.repository.AuthRepository
+import kr.tekit.lion.daongil.domain.repository.BookmarkRepository
+import kr.tekit.lion.daongil.domain.repository.PlaceDetailInfoGuestRepository
 import kr.tekit.lion.daongil.domain.repository.PlaceDetailInfoRepository
+import kr.tekit.lion.daongil.domain.usecase.GetPlaceDetailInfoGuestUseCase
 import kr.tekit.lion.daongil.domain.usecase.GetPlaceDetailInfoUseCase
+import kr.tekit.lion.daongil.domain.usecase.UpdatePlaceBookmarkUseCase
 
-class DetailViewModelFactory : ViewModelProvider.Factory{
+class DetailViewModelFactory(context: Context) : ViewModelProvider.Factory{
+    private val authRepository = AuthRepository.create(context)
     private val placeDetailInfoRepository = PlaceDetailInfoRepository.crate()
+    private val placeDetailInfoGuestRepository = PlaceDetailInfoGuestRepository.create()
+    private val bookmarkRepository = BookmarkRepository.create()
 
     private val getPlaceDetailInfoUseCase = GetPlaceDetailInfoUseCase(placeDetailInfoRepository)
+    private val getPlaceDetailInfoGuestUseCase = GetPlaceDetailInfoGuestUseCase(placeDetailInfoGuestRepository)
+    private val updatePlaceBookmarkUseCase = UpdatePlaceBookmarkUseCase(bookmarkRepository)
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(DetailViewModel::class.java)) {
             return DetailViewModel(
-                getPlaceDetailInfoUseCase
+                authRepository,
+                getPlaceDetailInfoUseCase,
+                getPlaceDetailInfoGuestUseCase,
+                updatePlaceBookmarkUseCase
             ) as T
         }
         throw IllegalArgumentException("unknown ViewModel class")

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/adapter/HomeLocationRVAdapter.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/adapter/HomeLocationRVAdapter.kt
@@ -35,7 +35,7 @@ class HomeLocationRVAdapter(
 
         init {
             binding.root.setOnClickListener {
-                onClick.invoke(adapterPosition)
+                onClick.invoke(absoluteAdapterPosition)
             }
         }
         fun bind(aroundPlace: AroundPlace) {

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/adapter/HomeRecommendRVAdapter.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/adapter/HomeRecommendRVAdapter.kt
@@ -35,7 +35,7 @@ class HomeRecommendRVAdapter(
 
         init {
             binding.root.setOnClickListener {
-                onClick.invoke(adapterPosition)
+                onClick.invoke(absoluteAdapterPosition)
             }
         }
         fun bind(recommendPlace: RecommendPlace) {

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/HomeMainFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/HomeMainFragment.kt
@@ -43,6 +43,7 @@ import kr.tekit.lion.daongil.presentation.main.adapter.HomeVPAdapter
 import kr.tekit.lion.daongil.presentation.main.dialog.ModeSettingDialog
 import kr.tekit.lion.daongil.presentation.main.vm.HomeViewModel
 import kr.tekit.lion.daongil.presentation.main.vm.HomeViewModelFactory
+import java.io.IOException
 import java.util.Locale
 import java.util.Timer
 import kotlin.concurrent.scheduleAtFixedRate
@@ -230,14 +231,26 @@ class HomeMainFragment : Fragment(R.layout.fragment_home_main) {
             override fun onLocationResult(locationResult: LocationResult) {
                 for (location in locationResult.locations) {
                     val geocoder = Geocoder(requireContext(), Locale.getDefault())
-                    val addresses =
-                        geocoder.getFromLocation(location.latitude, location.longitude, 1)
-                    val address = addresses?.get(0)?.getAddressLine(0)
 
-                    val (area, sigungu) = splitAddress(address!!)
-                    binding.homeMyLocationTv.text = "$area $sigungu"
+                    for(i in 1..3) {
+                        try {
+                            val addresses =
+                                geocoder.getFromLocation(location.latitude, location.longitude, 1)
+                            val address = addresses?.get(0)?.getAddressLine(0)
 
-                    getAroundPlaceInfo(binding, area, sigungu)
+                            val (area, sigungu) = splitAddress(address!!)
+                            binding.homeMyLocationTv.text = "$area $sigungu"
+
+                            getAroundPlaceInfo(binding, area, sigungu)
+                            return
+                        } catch (e: IOException) {
+                            if (i == 4) {
+                                Log.e("HomeMainFragment", "Geocoder 위치 가져오기 실패", e)
+                            }
+                        }
+                        // 재시도 전 대기 시간
+                        Thread.sleep(1000)
+                    }
                 }
             }
         }

--- a/DaOnGil/app/src/main/res/layout/activity_detail.xml
+++ b/DaOnGil/app/src/main/res/layout/activity_detail.xml
@@ -149,6 +149,7 @@
                 android:text="기본 정보 내용"
                 android:textColor="@color/text_secondary"
                 android:textSize="@dimen/font_small1"
+                android:lineSpacingMultiplier="1.2"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/detail_basic_divider" />

--- a/DaOnGil/app/src/main/res/layout/item_home_vp.xml
+++ b/DaOnGil/app/src/main/res/layout/item_home_vp.xml
@@ -2,14 +2,14 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingHorizontal="@dimen/margin_small2" >
+    android:layout_height="match_parent" >
 
     <androidx.cardview.widget.CardView
         android:id="@+id/item_home_card"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginVertical="5dp"
+        android:layout_marginHorizontal="@dimen/margin_small2"
         app:cardCornerRadius="10dp"
         app:cardElevation="3dp"
         app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
## #️⃣연관된 이슈

- #158 

## 📝작업 내용

- 비로그인 시 관광지 상세보기 API 연결 (북마크 X, 토큰 X)
- 로그인 유무 분기처리
- 북마크 업데이트 API 연결

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
- 로그인 시 상세보기(북마크 o) 
https://github.com/APP-Android2/FinalProject-DaOnGil/assets/75196460/00e04c74-4d63-403b-99b1-0dd975806ecc

- 비로그인 시 상세보기(북마크 x) (비로그인은 북마크 외엔 똑같아서 이미지만 첨부합니다)
<img src="https://github.com/APP-Android2/FinalProject-DaOnGil/assets/75196460/9cc71293-f0f0-4501-a92e-90575595883d" width="40%" height="40%"/>

## 💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - 로그인 분기처리 찬호오빠 코드 쌔비지 했는데 맞는지 한번 확인 부탁드립니다~
  - 무장애 편의정보 (주차여부, 핵심동선 등등..)는 지금 데이터를 안보내주고 있어서 더미데이터 넣어야 할 것 같습니다
  - 관광지 상세 화면 로그인 분기처리해서 작업하는 김에 북마크A PI도 같이 연결했습니다!
