### PR TITLE
[#192] 일정 작성 기능 추가 및 변경

### DIFF
--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/request/NewPlanRequest.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/request/NewPlanRequest.kt
@@ -1,5 +1,6 @@
 package kr.tekit.lion.daongil.data.dto.remote.request
 
+import com.squareup.moshi.Json
 import kr.tekit.lion.daongil.data.dto.remote.base.AdapterProvider.Companion.JsonAdapter
 import kr.tekit.lion.daongil.domain.model.NewPlan
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
@@ -10,7 +11,7 @@ data class NewPlanRequest(
     val title: String,
     val startDate: String,
     val endDate: String,
-    val isPublic: Boolean = false,
+    @Json(name = "dailyplace")
     val dailyPlace: List<DailyPlaceRequest>,
 )
 
@@ -20,7 +21,6 @@ fun NewPlan.toRequestBody(): RequestBody {
             this.title,
             this.startDate,
             this.endDate,
-            this.isPublic,
             this.dailyPlace.map {
                 DailyPlaceRequest(
                     it.date,

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/NewPlan.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/NewPlan.kt
@@ -4,6 +4,5 @@ data class NewPlan(
     val title: String,
     val startDate: String,
     val endDate: String,
-    val isPublic: Boolean = false,
     val dailyPlace: List<DailyPlace>,
 )

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/ScheduleMainFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/ScheduleMainFragment.kt
@@ -1,12 +1,15 @@
 package kr.tekit.lion.daongil.presentation.main.fragment
 
-import android.content.Context
+import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.View
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.snackbar.Snackbar
 import kr.tekit.lion.daongil.R
 import kr.tekit.lion.daongil.databinding.FragmentScheduleMainBinding
 import kr.tekit.lion.daongil.domain.model.MyMainSchedule
@@ -33,13 +36,23 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main), ConfirmD
         )
     }
 
+    private val scheduleFormLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()){ result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            view?.let{
+                Snackbar.make(it, "일정이 저장되었습니다", Snackbar.LENGTH_LONG)
+                    .setBackgroundTint(ContextCompat.getColor(requireActivity(), R.color.text_secondary))
+                    .show()
+            }
+        }
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         val binding = FragmentScheduleMainBinding.bind(view)
 
         // initView(binding)
-        settingRecyclerView(binding, requireContext())
+        settingRecyclerView(binding)
         initNewScheduleButton(binding)
 
         initMoreViewClickListener(binding)
@@ -78,7 +91,7 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main), ConfirmD
     }*/
 
 
-    private fun settingRecyclerView(binding: FragmentScheduleMainBinding, context: Context) {
+    private fun settingRecyclerView(binding: FragmentScheduleMainBinding) {
 
         with(binding) {
             viewModel.myMainPlanList.observe(viewLifecycleOwner) {
@@ -129,7 +142,7 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main), ConfirmD
         if (isUser) {
             // 일정 추가 화면으로 이동
             val intent = Intent(requireActivity(), ScheduleFormActivity::class.java)
-            startActivity(intent)
+            scheduleFormLauncher.launch(intent)
         } else {
             // 비회원 -> 로그인 다이얼로그
             displayLoginDialog()

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/adapter/FormBookmarkedPlacesAdapter.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/adapter/FormBookmarkedPlacesAdapter.kt
@@ -8,7 +8,7 @@ import kr.tekit.lion.daongil.domain.model.BookmarkedPlace
 
 class FormBookmarkedPlacesAdapter(
     private val bookmarkedPlaces: List<BookmarkedPlace>,
-    private val onPlaceSelectedListener : (selectedPlaceId: Long) -> Unit
+    private val onPlaceSelectedListener : (selectedBookmarkPosition: Int) -> Unit
 ) : RecyclerView.Adapter<FormBookmarkedPlacesAdapter.FormBookmarkedPlacesViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int)
@@ -30,13 +30,16 @@ class FormBookmarkedPlacesAdapter(
 
     class FormBookmarkedPlacesViewHolder(
         private val binding: ItemFormBookmarkedPlacesBinding,
-        private val onPlaceSelectedListener : (selectedPlaceId: Long) -> Unit
+        private val onPlaceSelectedListener : (selectedBookmarkPosition: Int) -> Unit
     ) : RecyclerView.ViewHolder(binding.root) {
+        init {
+            binding.buttonBookmarkedPlace.setOnClickListener {
+                onPlaceSelectedListener(absoluteAdapterPosition)
+            }
+        }
+
         fun bind(place: BookmarkedPlace) {
             binding.buttonBookmarkedPlace.text = place.bookmarkedPlaceName
-            binding.buttonBookmarkedPlace.setOnClickListener {
-                onPlaceSelectedListener(place.bookmarkedPlaceId)
-            }
         }
     }
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/adapter/FormPlaceAdapter.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/adapter/FormPlaceAdapter.kt
@@ -20,14 +20,12 @@ class FormPlaceAdapter(
         return FormPlaceViewHolder(
             ItemFormPlaceBinding.inflate(inflater, parent, false),
             schedulePosition,
-            onRemoveItemClick = { schedulePosition, placePosition ->
-                onRemoveButtonClick(schedulePosition,placePosition)
-            }
+            onRemoveButtonClick
         )
     }
 
     override fun onBindViewHolder(holder: FormPlaceViewHolder, position: Int) {
-        holder.bind(places[position], position)
+        holder.bind(places[position])
     }
 
     override fun getItemCount(): Int {
@@ -39,10 +37,18 @@ class FormPlaceAdapter(
         private val schedulePosition: Int,
         private val onRemoveItemClick: (schedulePosition: Int, placePosition: Int) -> Unit
     ) : RecyclerView.ViewHolder(binding.root) {
-        fun bind(place: FormPlace, placePosition: Int) {
+        init {
+            binding.imageButtonFPlaceRemove.setOnClickListener {
+                onRemoveItemClick(schedulePosition, absoluteAdapterPosition)
+            }
+        }
+
+        fun bind(place: FormPlace) {
             binding.apply {
                 textViewFPlaceAddr.text = place.placeAddress
                 textViewFPlaceName.text = place.placeName
+
+                initDisabilityIcons()
                 place.placeDisability.forEach {
                     when (it) {
                         1 -> iconFPlacePhysicalDisability.visibility = View.VISIBLE
@@ -61,9 +67,15 @@ class FormPlaceAdapter(
                         .into(imageViewFPlaceThumbnail)
                 }
             }
+        }
 
-            binding.imageButtonFPlaceRemove.setOnClickListener {
-                onRemoveItemClick(schedulePosition, placePosition)
+        private fun initDisabilityIcons(){
+            binding.apply {
+                iconFPlacePhysicalDisability.visibility = View.GONE
+                iconFPlaceVisualImpair.visibility = View.GONE
+                iconFPlaceHearingImpair.visibility = View.GONE
+                iconFPlaceInfantFamily.visibility = View.GONE
+                iconFPlaceElderlyPeople.visibility = View.GONE
             }
         }
     }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/adapter/FormScheduleAdapter.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/adapter/FormScheduleAdapter.kt
@@ -16,10 +16,7 @@ class FormScheduleAdapter(
         val inflater = LayoutInflater.from(parent.context)
         return FormScheduleViewHolder(
             ItemFormScheduleBinding.inflate(inflater, parent, false),
-            onAddItemClick = { schedulePosition ->
-                // '여행지 추가' 버튼 클릭리스너 -> 다음 화면으로 이동시켜준다. (스케쥴 position 전달)
-                this.onAddButtonClickListener(schedulePosition)
-            },
+            onAddButtonClickListener,
             onRemoveButtonClickListener
         )
     }
@@ -34,20 +31,22 @@ class FormScheduleAdapter(
 
     class FormScheduleViewHolder(
         private val binding: ItemFormScheduleBinding,
-        private val onAddItemClick : (schedulePosition: Int) -> Unit,
+        private val onAddButtonClickListener : (schedulePosition: Int) -> Unit,
         private val onRemoveButtonClickListener : (schedulePosition: Int, placePosition: Int) -> Unit
     ) : RecyclerView.ViewHolder(binding.root) {
+        init {
+            // 여행지 추가 버튼
+            binding.buttonFScheduleAddPlace.setOnClickListener {
+                onAddButtonClickListener(absoluteAdapterPosition)
+            }
+        }
+
         fun bind(dailySchedule: DailySchedule) {
             binding.textViewFScheduleDate.text = dailySchedule.dailyDate
 
             // 추가할 여행지목록 Adapter
-            val formPlaceAdapter = FormPlaceAdapter(dailySchedule.dailyPlaces, layoutPosition, onRemoveButtonClickListener)
+            val formPlaceAdapter = FormPlaceAdapter(dailySchedule.dailyPlaces, absoluteAdapterPosition, onRemoveButtonClickListener)
             binding.recyclerViewFSchedulePlaces.adapter = formPlaceAdapter
-
-            // 여행지 추가 버튼
-            binding.buttonFScheduleAddPlace.setOnClickListener {
-                onAddItemClick(layoutPosition)
-            }
         }
     }
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/adapter/FormSearchResultAdapter.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/adapter/FormSearchResultAdapter.kt
@@ -10,7 +10,7 @@ import kr.tekit.lion.daongil.domain.model.PlaceSearchInfo
 
 class FormSearchResultAdapter(
     private val searchResult: List<PlaceSearchInfo>,
-    private val onPlaceSelectedListener : (selectedPlaceId: Long) -> Unit
+    private val onPlaceSelectedListener : (selectedPlacePosition: Int) -> Unit
 ) : RecyclerView.Adapter<FormSearchResultAdapter.FormSearchResultViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FormSearchResultViewHolder {
@@ -31,8 +31,13 @@ class FormSearchResultAdapter(
 
     class FormSearchResultViewHolder(
         private val binding: ItemFormSearchResultBinding,
-        private val onPlaceSelectedListener : (selectedPlaceId: Long) -> Unit
+        private val onPlaceSelectedListener : (selectedPlacePosition: Int) -> Unit
     ) : RecyclerView.ViewHolder(binding.root) {
+        init {
+            binding.imageButtonSearchResultAdd.setOnClickListener {
+                onPlaceSelectedListener(absoluteAdapterPosition)
+            }
+        }
         fun bind(placeSearchInfo: PlaceSearchInfo) {
             binding.apply {
                 textViewSearchResultName.text = placeSearchInfo.placeName
@@ -43,10 +48,6 @@ class FormSearchResultAdapter(
                         .placeholder(R.drawable.empty_view_small)
                         .error(R.drawable.empty_view_small)
                         .into(imageViewSearchResultThumbnail)
-                }
-
-                imageButtonSearchResultAdd.setOnClickListener {
-                    onPlaceSelectedListener(placeSearchInfo.placeId)
                 }
             }
         }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/FormSearchFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/FormSearchFragment.kt
@@ -67,8 +67,9 @@ class FormSearchFragment : Fragment(R.layout.fragment_form_search) {
         scheduleFormViewModel.placeSearchResult.observe(viewLifecycleOwner){
             if(it.placeInfoList.isNotEmpty()){
                 binding.recyclerViewFSResult.apply {
-                    adapter = FormSearchResultAdapter(it.placeInfoList){ selectedPlaceId ->
-                        addNewPlace(this, schedulePosition, selectedPlaceId)
+                    adapter = FormSearchResultAdapter(it.placeInfoList){ selectedPlacePosition ->
+                        val placeId = it.placeInfoList[selectedPlacePosition].placeId
+                        addNewPlace(this, schedulePosition, placeId)
                     }
                 }
             }else{

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/FormSearchFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/FormSearchFragment.kt
@@ -49,7 +49,8 @@ class FormSearchFragment : Fragment(R.layout.fragment_form_search) {
             if(it.isNotEmpty()){
                 binding.recyclerViewFSBookmark.apply {
                     adapter = FormBookmarkedPlacesAdapter(it){ selectedPlaceId ->
-                        addNewPlace(this, schedulePosition, selectedPlaceId)
+                        val placeId = it[selectedPlaceId].bookmarkedPlaceId
+                        addNewPlace(this, schedulePosition, placeId)
                     }
                 }
             }else{

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/NameAndPeriodFormFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/NameAndPeriodFormFragment.kt
@@ -1,6 +1,7 @@
 package kr.tekit.lion.daongil.presentation.scheduleform.fragment
 
 
+import android.app.Activity
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.View
@@ -33,6 +34,7 @@ class NameAndPeriodFormFragment : Fragment(R.layout.fragment_name_and_period_for
 
     private fun initToolbar(binding: FragmentNameAndPeriodFormBinding){
         binding.toolbarNPF.setNavigationOnClickListener {
+            requireActivity().setResult(Activity.RESULT_CANCELED)
             requireActivity().finish()
         }
     }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/NameAndPeriodFormFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/NameAndPeriodFormFragment.kt
@@ -3,24 +3,25 @@ package kr.tekit.lion.daongil.presentation.scheduleform.fragment
 
 import android.app.Activity
 import android.os.Bundle
+import android.os.SystemClock
 import androidx.fragment.app.Fragment
 import android.view.View
+import android.view.inputmethod.InputMethodManager
+import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.datepicker.MaterialDatePicker
 import kr.tekit.lion.daongil.R
 import kr.tekit.lion.daongil.databinding.FragmentNameAndPeriodFormBinding
-import kr.tekit.lion.daongil.presentation.main.dialog.ConfirmDialog
-import kr.tekit.lion.daongil.presentation.main.dialog.ConfirmDialogInterface
 import kr.tekit.lion.daongil.presentation.scheduleform.vm.ScheduleFormViewModel
 import kr.tekit.lion.daongil.presentation.scheduleform.vm.ScheduleFormViewModelFactory
 import java.text.SimpleDateFormat
 import java.util.*
+import kotlin.concurrent.thread
 
-class NameAndPeriodFormFragment : Fragment(R.layout.fragment_name_and_period_form),
-    ConfirmDialogInterface {
+class NameAndPeriodFormFragment : Fragment(R.layout.fragment_name_and_period_form) {
     // activity의 뷰모델
-    private val scheduleFormViewModel : ScheduleFormViewModel by activityViewModels{ ScheduleFormViewModelFactory() }
+    private val scheduleFormViewModel: ScheduleFormViewModel by activityViewModels { ScheduleFormViewModelFactory() }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -30,24 +31,27 @@ class NameAndPeriodFormFragment : Fragment(R.layout.fragment_name_and_period_for
         initToolbar(binding)
         setPeriod(binding)
         proceedToNext(binding)
+
+        showSoftInput(binding.editTextNPFName)
     }
 
-    private fun initToolbar(binding: FragmentNameAndPeriodFormBinding){
+    private fun initToolbar(binding: FragmentNameAndPeriodFormBinding) {
         binding.toolbarNPF.setNavigationOnClickListener {
             requireActivity().setResult(Activity.RESULT_CANCELED)
             requireActivity().finish()
         }
     }
 
-    private fun proceedToNext(binding: FragmentNameAndPeriodFormBinding){
+    private fun proceedToNext(binding: FragmentNameAndPeriodFormBinding) {
         binding.apply {
             buttonNPFNextStep.setOnClickListener {
                 val isNameAndPeriodValidate = validateScheduleNameAndPeriod(this)
-                if(isNameAndPeriodValidate){
+                if (isNameAndPeriodValidate) {
                     scheduleFormViewModel.setTitle(editTextNPFName.text.toString())
 
                     val navController = findNavController()
-                    val action = NameAndPeriodFormFragmentDirections.actionNameAndPeriodFormFragmentToScheduleDetailsFormFragment()
+                    val action =
+                        NameAndPeriodFormFragmentDirections.actionNameAndPeriodFormFragmentToScheduleDetailsFormFragment()
                     navController.navigate(action)
                 }
             }
@@ -91,37 +95,56 @@ class NameAndPeriodFormFragment : Fragment(R.layout.fragment_name_and_period_for
             getString(R.string.picked_dates, startDateFormatted, endDateFormatted)
     }
 
-    private fun validateScheduleNameAndPeriod(binding: FragmentNameAndPeriodFormBinding) : Boolean{
+    private fun validateScheduleNameAndPeriod(binding: FragmentNameAndPeriodFormBinding): Boolean {
         val tempName = binding.editTextNPFName.text.toString()
 
-        if(tempName.isEmpty()){
-            displayValidationDialog("제목 입력 안내", "최소 1글자 이상 입력해주세요.")
+        if (tempName.isEmpty()) {
+            displayValidationDialog(binding, "제목 입력 안내", "최소 1글자 이상 입력해주세요.", true)
             return false
         }
-        if(tempName.length > 15){
-            displayValidationDialog("제목 입력 안내", "제목은 15글자 이하로 입력해주세요.")
+        if (tempName.length > 15) {
+            displayValidationDialog(binding, "제목 입력 안내", "제목은 15글자 이하로 입력해주세요.", true)
             return false
         }
         val tempStartDate = scheduleFormViewModel.startDate.value
 
-        if(tempStartDate == null){
-            displayValidationDialog("여행 기간 안내", "여행 기간 설정하기 버튼을 눌러 여행 기간을 설정해주세요")
+        if (tempStartDate == null) {
+            displayValidationDialog(binding, "여행 기간 안내", "여행 기간 설정하기 버튼을 눌러 여행 기간을 설정해주세요", false)
             return false
         }
 
         return true
     }
-    private fun displayValidationDialog(title:String, subTitle:String, ){
-        val dialog = ConfirmDialog(
-            this,
+
+    private fun displayValidationDialog(
+        binding: FragmentNameAndPeriodFormBinding,
+        title: String,
+        subTitle: String,
+        isNameEmpty: Boolean
+    ) {
+        val dialog = kr.tekit.lion.daongil.presentation.myinfo.ConfirmDialog(
             title,
             subTitle,
             getString(R.string.confirm),
             R.color.primary,
-            R.color.text_primary)
+            R.color.text_primary
+        ) {
+            if (isNameEmpty) {
+                showSoftInput(binding.editTextNPFName)
+            }
+        }
         dialog.isCancelable = false
         dialog.show(activity?.supportFragmentManager!!, "ScheduleLoginDialog")
     }
 
-    override fun onPosBtnClick() { }
+    fun showSoftInput(view: View) {
+        view.requestFocus()
+
+        thread {
+            SystemClock.sleep(400)
+            val inputMethodManager =
+                requireActivity().getSystemService(AppCompatActivity.INPUT_METHOD_SERVICE) as InputMethodManager
+            inputMethodManager.showSoftInput(view, 0)
+        }
+    }
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ScheduleDetailsFormFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ScheduleDetailsFormFragment.kt
@@ -1,8 +1,10 @@
 package kr.tekit.lion.daongil.presentation.scheduleform.fragment
 
 import android.app.Activity
+import android.content.Context
 import android.os.Bundle
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -25,6 +27,22 @@ class ScheduleDetailsFormFragment : Fragment(R.layout.fragment_schedule_details_
         ScheduleFormViewModelFactory()
     }
 
+    private val onBackPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            resetForm()
+        }
+    }
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        requireActivity().onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        onBackPressedCallback.remove()
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -44,13 +62,17 @@ class ScheduleDetailsFormFragment : Fragment(R.layout.fragment_schedule_details_
 
     private fun initToolbar(binding: FragmentScheduleDetailsFormBinding) {
         binding.toolbarScheduleDetailsForm.setNavigationOnClickListener {
-            // 날짜 선택화면으로 돌아가는 경우 제목, 기간, 리스트 초기화
-            scheduleFormViewModel.setTitle(null)
-            scheduleFormViewModel.setStartDate(null)
-            scheduleFormViewModel.setEndDate(null)
-            scheduleFormViewModel.setSchedule(null)
-            findNavController().popBackStack()
+            resetForm()
         }
+    }
+
+    private fun resetForm(){
+        // 날짜 선택화면으로 돌아가는 경우 제목, 기간, 리스트 초기화
+        scheduleFormViewModel.setTitle(null)
+        scheduleFormViewModel.setStartDate(null)
+        scheduleFormViewModel.setEndDate(null)
+        scheduleFormViewModel.setSchedule(null)
+        findNavController().popBackStack()
     }
 
     private fun initScheduleList() {

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ScheduleDetailsFormFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ScheduleDetailsFormFragment.kt
@@ -1,10 +1,13 @@
 package kr.tekit.lion.daongil.presentation.scheduleform.fragment
 
+import android.app.Activity
 import android.os.Bundle
 import android.view.View
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
+import com.google.android.material.snackbar.Snackbar
 import kr.tekit.lion.daongil.R
 import kr.tekit.lion.daongil.databinding.FragmentScheduleDetailsFormBinding
 import kr.tekit.lion.daongil.domain.model.DailySchedule
@@ -17,6 +20,7 @@ import java.util.*
 import java.util.concurrent.TimeUnit
 
 class ScheduleDetailsFormFragment : Fragment(R.layout.fragment_schedule_details_form) {
+
     private val scheduleFormViewModel: ScheduleFormViewModel by activityViewModels{
         ScheduleFormViewModelFactory()
     }
@@ -120,14 +124,21 @@ class ScheduleDetailsFormFragment : Fragment(R.layout.fragment_schedule_details_
     }
 
     private fun initButtonSubmit(binding: FragmentScheduleDetailsFormBinding){
-        binding.buttonDFSubmit.setOnClickListener {
-            scheduleFormViewModel.submitNewPlan{
-                if(it){
+        binding.buttonDFSubmit.setOnClickListener { view ->
+            scheduleFormViewModel.submitNewPlan{ _, requestFlag ->
+                if(requestFlag){
+                    requireActivity().setResult(Activity.RESULT_OK)
                     requireActivity().finish()
                 }else{
-                    // to do
+                    showSnackBar(view, "다시 시도해주세요")
                 }
             }
         }
+    }
+
+    private fun showSnackBar(view: View, message : String ){
+        Snackbar.make(view, message, Snackbar.LENGTH_LONG)
+            .setBackgroundTint(ContextCompat.getColor(requireActivity(), R.color.text_secondary))
+            .show()
     }
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/vm/ScheduleFormViewModel.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/vm/ScheduleFormViewModel.kt
@@ -146,7 +146,7 @@ class ScheduleFormViewModel(
         val dailyPlace = getDailyPlaceList()
 
         if (title != null && startDateString != null && endDateString != null) {
-            val newPlan = NewPlan(title, startDateString, endDateString, false, dailyPlace)
+            val newPlan = NewPlan(title, startDateString, endDateString, dailyPlace)
 
             viewModelScope.launch {
                 val success = try {

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/vm/ScheduleFormViewModel.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/vm/ScheduleFormViewModel.kt
@@ -139,7 +139,7 @@ class ScheduleFormViewModel(
         }
     }
 
-    fun submitNewPlan(callback: (Boolean) -> Unit) {
+    fun submitNewPlan(callback: (Boolean, Boolean) -> Unit) {
         val title = _title.value
         val startDateString = _startDate.value?.let { formatDateValue(it) }
         val endDateString = _endDate.value?.let { formatDateValue(it) }
@@ -148,9 +148,12 @@ class ScheduleFormViewModel(
         if (title != null && startDateString != null && endDateString != null) {
             val newPlan = NewPlan(title, startDateString, endDateString, dailyPlace)
 
+            var requestFlag = false
+
             viewModelScope.launch {
                 val success = try {
                     addNewPlanUseCase(newPlan).onSuccess {
+                        requestFlag = true
                     }.onError {
                         Log.d("submitNewPlan", "onError : ${it}")
                     }
@@ -159,8 +162,8 @@ class ScheduleFormViewModel(
                     Log.d("submitNewPlan", "Error: ${e.message}")
                     false
                 }
-                // 작업한 결과가 끝나면 true를 반환해준다.
-                callback(success)
+                // 작업한 결과가 끝나면 success에 true를 반환해준다.
+                callback(success, requestFlag)
             }
         }
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #192 

## 📝작업 내용

- 일정 작성 API 변경사항 반영 (isPublic 삭제됨)
- 리사이클러뷰에 사용된 클릭리스너 위치 변경 (리팩토링)
- 일정이 정상적으로 저장된 경우 일정 메인화면으로 돌아갔을 때 Snackbar 띄워주기
- 일정 작성 두 번째 화면에서 뒤로 가기 버튼 눌렀을 때, 작성한 내용 초기화 되지 않는 문제 해결
- 일정 제목 작성하는 화면에서 제목에 focus 주고, 키보드 보여주기

## PR 발행 전 체크 리스트

- [ ] 발행자 확인
- [ ] 프로젝트 설정 확인
- [ ] 라벨 확인


## 💬리뷰 요구사항(선택)

- 일정이 제대로 저장되지 않았는데도, ScheduleFormViewModel - submitNewPlan의 callback이 실행되어서 일정 메인화면으로 되돌아가는 문제가 있었습니다. 그래서 이 문제를 해결하려고, 
1) requestFlag라는 var 를 생성해서, 
2) 정상적으로 서버에 저장된 경우 requestFlag 값을 true로 설정해주고,
3) true를 반환할 때만 일정 메인화면으로 돌아가게 코드를 작성했습니다.

이런 방법으로 해결해도 될까요? 혹시 이 방법말고 더 좋은 방법이 있을까요?


- 페이징은 어떤 식으로 처리하면 좋을까 찾아보다가.. 찬호님이 확장함수 만들어주신다고 들어서 그 부분은 제외하고 수정했습니다.
