### PR TITLE
[#220] 나의 여행지 후기 삭제 api 연결

### DIFF
--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/datasource/PlaceDataSource.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/datasource/PlaceDataSource.kt
@@ -73,4 +73,8 @@ class PlaceDataSource(
     suspend fun writePlaceReviewData(placeId: Long, placeReviewReq: RequestBody, images: List<MultipartBody.Part>): ResponseBody {
         return placeService.writePlaceReviewData(placeId, placeReviewReq, images)
     }
+
+    suspend fun deleteMyPlaceReview(reviewId: Long) {
+        placeService.deleteMyPlaceReview(reviewId)
+    }
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/myreview/MyPlaceReviewResponse.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/myreview/MyPlaceReviewResponse.kt
@@ -3,7 +3,6 @@ package kr.tekit.lion.daongil.data.dto.remote.response.myreview
 import com.squareup.moshi.JsonClass
 import kr.tekit.lion.daongil.domain.model.MyPlaceReview
 import kr.tekit.lion.daongil.domain.model.MyPlaceReviewInfo
-import java.time.LocalDate
 
 @JsonClass(generateAdapter = true)
 data class MyPlaceReviewResponse(
@@ -21,7 +20,7 @@ data class MyPlaceReviewResponse(
                     images = it.images,
                     name = it.name,
                     placeId = it.placeId,
-                    reviewId = it.placeId
+                    reviewId = it.reviewId
                 )
             },
             pageNo = data.pageNo,

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/service/PlaceService.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/service/PlaceService.kt
@@ -11,6 +11,7 @@ import kr.tekit.lion.daongil.data.network.AuthType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import okhttp3.ResponseBody
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Multipart
 import retrofit2.http.POST
@@ -84,4 +85,9 @@ interface PlaceService {
         @Part("placeReviewReq") placeReviewReq: RequestBody,
         @Part images : List<MultipartBody.Part>?
     ): ResponseBody
+
+    @DELETE("place/review/my/{reviewId}")
+    suspend fun deleteMyPlaceReview(
+        @Path("reviewId") reviewId: Long
+    )
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/repository/PlaceRepositoryImpl.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/repository/PlaceRepositoryImpl.kt
@@ -61,4 +61,8 @@ class PlaceRepositoryImpl(
     override suspend fun writePlaceReviewData(placeId: Long, newReviewData: NewReviewData, reviewImages: NewReviewImages) : ResponseBody {
         return placeDataSource.writePlaceReviewData(placeId, newReviewData.toRequestBody(), reviewImages.toMultiPartBody())
     }
+
+    override suspend fun deleteMyPlaceReview(reviewId: Long) {
+        return placeDataSource.deleteMyPlaceReview(reviewId)
+    }
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/repository/PlaceRepository.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/repository/PlaceRepository.kt
@@ -27,6 +27,7 @@ interface PlaceRepository {
     suspend fun getMyPlaceReview(size: Int, page: Int): MyPlaceReview
     suspend fun getPlaceReviewList(placeId: Long, size: Int, page: Int): PlaceReviewInfo
     suspend fun writePlaceReviewData(placeId: Long, newReviewData: NewReviewData, reviewImages: NewReviewImages): ResponseBody
+    suspend fun deleteMyPlaceReview(reviewId: Long)
     companion object{
         fun create(): PlaceRepositoryImpl{
             return PlaceRepositoryImpl(

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/place/DeleteMyPlaceReviewUseCase.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/place/DeleteMyPlaceReviewUseCase.kt
@@ -1,0 +1,13 @@
+package kr.tekit.lion.daongil.domain.usecase.place
+
+import kr.tekit.lion.daongil.domain.repository.PlaceRepository
+import kr.tekit.lion.daongil.domain.usecase.base.BaseUseCase
+import kr.tekit.lion.daongil.domain.usecase.base.Result
+
+class DeleteMyPlaceReviewUseCase(
+    private val placeRepository: PlaceRepository
+): BaseUseCase() {
+    suspend operator fun invoke(reviewId: Long) : Result<Unit> = execute {
+        placeRepository.deleteMyPlaceReview(reviewId)
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/myreview/fragment/MyReviewFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/myreview/fragment/MyReviewFragment.kt
@@ -53,7 +53,7 @@ class MyReviewFragment : Fragment(R.layout.fragment_my_review) {
                             "삭제한 데이터는 되돌릴 수 없습니다.",
                             "삭제하기"
                         ) {
-                            // 삭제하기 api
+                            viewModel.deleteMyPlaceReview(reviewId)
                         }
                     }
                 )

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/myreview/vm/MyReviewViewModel.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/myreview/vm/MyReviewViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.launch
 import kr.tekit.lion.daongil.domain.model.MyPlaceReview
 import kr.tekit.lion.daongil.domain.usecase.base.onError
 import kr.tekit.lion.daongil.domain.usecase.base.onSuccess
+import kr.tekit.lion.daongil.domain.usecase.place.DeleteMyPlaceReviewUseCase
 import kr.tekit.lion.daongil.domain.usecase.place.GetMyPlaceReviewUseCase
 
 class MyReviewViewModel(
@@ -21,6 +22,7 @@ class MyReviewViewModel(
     private val _isLastPage = MutableLiveData<Boolean>()
     val isLastPage: LiveData<Boolean> = _isLastPage
 
+    private var isRequesting = false
 
     init {
         _isLastPage.value = false
@@ -30,26 +32,36 @@ class MyReviewViewModel(
     private fun getMyPlaceReview(size: Int, page: Int) = viewModelScope.launch {
         getMyPlaceReviewUseCase(size, page).onSuccess {
             _myPlaceReview.value = it
+            _isLastPage.value = it.myPlaceReviewInfoList.size < size
         }.onError {
             Log.d("getMyPlaceReview", it.toString())
         }
     }
 
     fun getNextMyPlaceReview(size: Int) = viewModelScope.launch {
-        val page = _myPlaceReview.value?.pageNo
+        val page = _myPlaceReview.value?.pageNo ?:0
 
-        if (page != null) {
-            getMyPlaceReviewUseCase(size, page+1).onSuccess { newReviews ->
-                if (newReviews.myPlaceReviewInfoList.isEmpty()) {
+        if (_isLastPage.value == false && !isRequesting) {
+            isRequesting = true
+
+            getMyPlaceReviewUseCase(size, page + 1).onSuccess { newReviews ->
+                val currentReviews = _myPlaceReview.value?.myPlaceReviewInfoList ?: emptyList()
+                val updatedReviews = currentReviews + newReviews.myPlaceReviewInfoList
+                val updatedReviewData = newReviews.copy(myPlaceReviewInfoList = updatedReviews)
+                _myPlaceReview.value = updatedReviewData
+
+                if (newReviews.myPlaceReviewInfoList.size < size) {
                     _isLastPage.value = true
-                } else {
-                    val currentReviews = _myPlaceReview.value?.myPlaceReviewInfoList ?: emptyList()
-                    val updatedReviews = currentReviews + newReviews.myPlaceReviewInfoList
-                    val updatedReviewData = newReviews.copy(myPlaceReviewInfoList = updatedReviews)
-                    _myPlaceReview.value = updatedReviewData
                 }
+
+                Log.d("MyReviewViewModel", "currentReviews : ${currentReviews}")
+                Log.d("MyReviewViewModel", "updatedReviews : ${updatedReviews}")
+                Log.d("MyReviewViewModel", "updatedReviewData : ${updatedReviewData}")
+                Log.d("MyReviewViewModel", _isLastPage.value.toString())
             }.onError {
                 Log.d("getNextMyPlaceReview", it.toString())
+            }.also {
+                isRequesting = false
             }
         }
     }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/myreview/vm/MyReviewViewModelFactory.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/myreview/vm/MyReviewViewModelFactory.kt
@@ -3,16 +3,21 @@ package kr.tekit.lion.daongil.presentation.myreview.vm
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import kr.tekit.lion.daongil.domain.repository.PlaceRepository
+import kr.tekit.lion.daongil.domain.usecase.place.DeleteMyPlaceReviewUseCase
 import kr.tekit.lion.daongil.domain.usecase.place.GetMyPlaceReviewUseCase
 
 class MyReviewViewModelFactory : ViewModelProvider.Factory {
 
     private val placeRepository = PlaceRepository.create()
     private val getMyPlaceReviewUseCase = GetMyPlaceReviewUseCase(placeRepository)
+    private val deleteMyPlaceReviewUseCase = DeleteMyPlaceReviewUseCase(placeRepository)
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(MyReviewViewModel::class.java)) {
-            return MyReviewViewModel(getMyPlaceReviewUseCase) as T
+            return MyReviewViewModel(
+                getMyPlaceReviewUseCase,
+                deleteMyPlaceReviewUseCase
+            ) as T
         }
         throw IllegalArgumentException("unknown ViewModel class")
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #220 

## 📝작업 내용

- 나의 여행지 후기 삭제 api 연결

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
1. **MyReviewViewModel의 isRequesting**
리뷰를 불러와서 마지막 페이지일 때 isLastPage가 true로 바뀌었음에도 마지막 페이지를 또 불러와서 데이터가 중복되어 보이는 문제가 있었습니다. 아래 코드처럼 isRequesting 프로퍼티로 처리를 해줬는데 괜찮을까요?
```kotlin
class MyReviewViewModel(
    private val getMyPlaceReviewUseCase: GetMyPlaceReviewUseCase,
    private val deleteMyPlaceReviewUseCase: DeleteMyPlaceReviewUseCase
) : ViewModel() {

    private val _myPlaceReview = MutableLiveData<MyPlaceReview>()
    val myPlaceReview: LiveData<MyPlaceReview> = _myPlaceReview

    private val _isLastPage = MutableLiveData<Boolean>()
    val isLastPage: LiveData<Boolean> = _isLastPage

    private var isRequesting = false

    fun getNextMyPlaceReview(size: Int) = viewModelScope.launch {
        val page = _myPlaceReview.value?.pageNo ?:0

        if (_isLastPage.value == false && !isRequesting) {
            isRequesting = true

            getMyPlaceReviewUseCase(size, page + 1).onSuccess { newReviews ->
                val currentReviews = _myPlaceReview.value?.myPlaceReviewInfoList ?: emptyList()
                val updatedReviews = currentReviews + newReviews.myPlaceReviewInfoList
                val updatedReviewData = newReviews.copy(myPlaceReviewInfoList = updatedReviews)
                _myPlaceReview.value = updatedReviewData

                if (newReviews.pageNo == newReviews.totalPages) {
                    _isLastPage.value = true
                }

                Log.d("MyReviewViewModel", "getNextMyPlaceReview")
            }.onError {
                Log.d("getNextMyPlaceReview", it.toString())
            }.also {
                isRequesting = false
            }
        }
    }
``` 
<br/>

2. **여행지 후기 삭제 관련**
```kotlin
fun deleteMyPlaceReview(reviewId: Long) {
        viewModelScope.launch {
            deleteMyPlaceReviewUseCase(reviewId).onSuccess {
                _myPlaceReview.value?.let { currentReviewData ->
                    val updatedReviews =
                        currentReviewData.myPlaceReviewInfoList.filter { it.reviewId != reviewId }
                    val updatedReviewData = currentReviewData.copy(
                        myPlaceReviewInfoList = updatedReviews,
                        reviewNum = currentReviewData.reviewNum - 1
                    )
                    _myPlaceReview.value = updatedReviewData
                }
            }.onError {
                Log.d("deleteMyPlaceReview", it.toString())
            }
        }
    }
``` 
여행지 후기 삭제에서 발생하는 문제가 있습니다. 
n번째 순서에 있는 후기를 삭제하고 다음 페이지의 후기 데이터를 불러올 때, n번째 순서에 있던 후기가 삭제되었고, 그로인해 n+1번째 순서에 있던 후기가 n번째 순서가 되었기 때문에 n+2번째 후기부터 불러오게 됩니다. 
아예 지금까지 불러온 페이지만큼 데이터를 다시 불러오는 것도 생각했지만, 후기가 많을 경우나 이래저래 생각해봤을 때 딱히 좋은 방법은 아니라는 생각이 들어서 우선, 삭제한 후기를 제거하는 부분만 작성해서 PR 올립니다.... (ㅜㅅ ㅜ)
**_여러분의 지혜가 필요합니당....🙏🏻_**