### PR TITLE
[#227] 관광정보 상세보기 후기 버튼 설정 수정

### DIFF
--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/mainplace/AroundPlaceRes.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/mainplace/AroundPlaceRes.kt
@@ -8,5 +8,5 @@ data class AroundPlaceRes(
     val disability: List<String>,
     val image: String,
     val name: String,
-    val placeId: Int
+    val placeId: Long
 )

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/mainplace/RecommendPlaceRes.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/mainplace/RecommendPlaceRes.kt
@@ -8,5 +8,5 @@ data class RecommendPlaceRes(
     val disability: List<String>,
     val image: String,
     val name: String,
-    val placeId: Int
+    val placeId: Long
 )

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/searchplace/list/PlaceRes.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/searchplace/list/PlaceRes.kt
@@ -10,5 +10,5 @@ data class PlaceRes(
     val mapX: String,
     val mapY: String,
     val name: String,
-    val placeId: Int
+    val placeId: Long
 )

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/AroundPlace.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/AroundPlace.kt
@@ -6,5 +6,5 @@ data class AroundPlace (
     val disability: List<String>,
     val image: String,
     val name: String,
-    val placeId: Int
+    val placeId: Long
 )

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/RecommendPlace.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/RecommendPlace.kt
@@ -5,5 +5,5 @@ data class RecommendPlace (
     val disability: List<String>,
     val image: String,
     val name: String,
-    val placeId: Int
+    val placeId: Long
 )

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/home/DetailActivity.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/home/DetailActivity.kt
@@ -33,8 +33,8 @@ import kr.tekit.lion.daongil.presentation.home.vm.DetailViewModelFactory
 import kr.tekit.lion.daongil.presentation.login.LogInState
 
 class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
-    private val viewModel : DetailViewModel by viewModels { DetailViewModelFactory(this) }
-    private val binding : ActivityDetailBinding by lazy {
+    private val viewModel: DetailViewModel by viewModels { DetailViewModelFactory(this) }
+    private val binding: ActivityDetailBinding by lazy {
         ActivityDetailBinding.inflate(layoutInflater)
     }
     private lateinit var naverMap: NaverMap
@@ -60,7 +60,7 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
         binding.detailDisabilityInfoRv.layoutManager = LinearLayoutManager(applicationContext)
     }
 
-    private fun settingReviewRVAdapter(reviewList : List<Review>) {
+    private fun settingReviewRVAdapter(reviewList: List<Review>) {
         if (reviewList.isEmpty()) {
             binding.detailReviewRv.visibility = View.GONE
             binding.detailNoReviewTv.visibility = View.VISIBLE
@@ -75,7 +75,7 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
         }
     }
 
-    private fun settingDisabilityRVAdapter(disabilityList : List<Int>) {
+    private fun settingDisabilityRVAdapter(disabilityList: List<Int>) {
         val disabilityRVAdapter = DetailDisabilityRVAdapter(disabilityList)
         binding.detailDisabilityIvRv.adapter = disabilityRVAdapter
         binding.detailDisabilityIvRv.layoutManager = GridLayoutManager(applicationContext, 3)
@@ -87,7 +87,12 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
         }
     }
 
-    private fun settingReviewBtn(placeId: Long, placeName: String, placeAddress: String, image: String?) {
+    private fun settingReviewBtn(
+        placeId: Long,
+        placeName: String,
+        placeAddress: String,
+        image: String?
+    ) {
         binding.detailMoreReviewBtn.setOnClickListener {
             val intent = Intent(this, ReviewListActivity::class.java)
             intent.putExtra("reviewPlaceId", placeId)
@@ -101,6 +106,10 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
             intent.putExtra("reviewPlaceAddress", placeAddress)
             intent.putExtra("reviewPlaceImage", image)
             startActivity(intent)
+        }
+
+        binding.detailModifyReviewBtn.setOnClickListener {
+
         }
     }
 
@@ -144,10 +153,10 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
         addMapMarker(longitude, latitude)
     }
 
-    private fun getDetailPlaceInfo(placeId : Long) {
+    private fun getDetailPlaceInfo(placeId: Long) {
         viewModel.getDetailPlace(placeId)
 
-        viewModel.detailPlaceInfo.observe(this@DetailActivity) {detailPlaceInfo ->
+        viewModel.detailPlaceInfo.observe(this@DetailActivity) { detailPlaceInfo ->
             handleCommonDetailPlaceInfo(
                 detailPlaceInfo.placeId,
                 detailPlaceInfo.reviewList,
@@ -181,13 +190,21 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
             }
 
             binding.detailBookmarkCount.text = detailPlaceInfo.bookmarkNum.toString()
+
+            if (detailPlaceInfo.isReview) {
+                binding.detailWriteReviewBtn.visibility = View.GONE
+                binding.detailModifyReviewBtn.visibility = View.VISIBLE
+            } else {
+                binding.detailWriteReviewBtn.visibility = View.VISIBLE
+                binding.detailModifyReviewBtn.visibility = View.GONE
+            }
         }
     }
 
-    private fun getDetailPlaceInfoGuest(placeId : Long) {
+    private fun getDetailPlaceInfoGuest(placeId: Long) {
         viewModel.getDetailPlaceGuest(placeId)
 
-        viewModel.detailPlaceInfoGuest.observe(this@DetailActivity) {detailPlaceInfoGuest ->
+        viewModel.detailPlaceInfoGuest.observe(this@DetailActivity) { detailPlaceInfoGuest ->
             handleCommonDetailPlaceInfo(
                 detailPlaceInfoGuest.placeId,
                 detailPlaceInfoGuest.reviewList,
@@ -203,6 +220,8 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
             )
             binding.detailBookmarkBtn.visibility = View.GONE
             binding.detailBookmarkCount.visibility = View.GONE
+            binding.detailWriteReviewBtn.visibility = View.GONE
+            binding.detailModifyReviewBtn.visibility = View.GONE
         }
     }
 
@@ -219,7 +238,8 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
         fusedLocationClient = LocationServices.getFusedLocationProviderClient(this)
 
         // 네이버 지도 SDK에 위치를 제공하는 인터페이스
-        mLocationSource = FusedLocationSource(this, EmergencyMapActivity.LOCATION_PERMISSION_REQUEST_CODE)
+        mLocationSource =
+            FusedLocationSource(this, EmergencyMapActivity.LOCATION_PERMISSION_REQUEST_CODE)
         // 네이버맵 동적으로 불러오기
         val fm = supportFragmentManager
         val mapFragment = fm.findFragmentById(R.id.detail_map) as MapFragment?
@@ -244,9 +264,11 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
                     is LogInState.Checking -> {
                         return@collect
                     }
+
                     is LogInState.LoggedIn -> {
                         getDetailPlaceInfo(recommendPlaceId)
                     }
+
                     is LogInState.LoginRequired -> {
                         getDetailPlaceInfoGuest(recommendPlaceId)
                     }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/home/ReviewListActivity.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/home/ReviewListActivity.kt
@@ -1,8 +1,6 @@
 package kr.tekit.lion.daongil.presentation.home
 
-import android.annotation.SuppressLint
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager

--- a/DaOnGil/app/src/main/res/layout/activity_detail.xml
+++ b/DaOnGil/app/src/main/res/layout/activity_detail.xml
@@ -339,6 +339,20 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="@+id/detail_review_tv" />
 
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/detail_modify_review_btn"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/margin_basic"
+                android:backgroundTint="@color/background_color"
+                android:text="수정하기"
+                android:fontFamily="@font/pretendard_semibold"
+                android:textColor="@color/text_secondary"
+                android:textSize="@dimen/font_small1"
+                app:layout_constraintBottom_toBottomOf="@+id/detail_review_tv"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/detail_review_tv"/>
+
             <com.google.android.material.divider.MaterialDivider
                 android:id="@+id/detail_review_divider"
                 android:layout_width="match_parent"


### PR DESCRIPTION
## #️⃣연관된 이슈

- #227 

## 📝작업 내용

- 관광정보 상세보기에서 후기 작성 완료 시 후기 작성 버튼 -> 수정하기 버튼으로 변경
- 관광정보 상세보기 게스트ver. -> 후기 작성 버튼 안보이도록 설정

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
https://github.com/user-attachments/assets/6cb64991-437a-403e-a75c-872d3153b123


## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - placeId를 Int로 받는 부분이 있어서 Long으로 수정했는데 찬호 오빠 파트도 같이 변경된 부분이 하나 있어서 (에러가 나는 부분은 없긴 했지만) 혹시나 확인 함 해주세요 ~
    - [placeId Long 타입으로 변경](https://github.com/Journey-Together/Android/commit/9769377636a67bd1dec85a9f03cf5fbfc14ea421) (DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/searchplace/list/PlaceRes.kt)
  - 버튼 디자인은 나중에 상세보기 화면 디자인 나오면 수정할 예정입니다
  - 수정하기 버튼 클릭 시 화면 이동은 추후에 정민언니랑 다시 상의하고 수정하기로 했습니다
