### PR TITLE
[#230] 관광정보 상세보기 데이터 추가

### DIFF
--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/detailPlaceGuest/Data.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/detailPlaceGuest/Data.kt
@@ -16,6 +16,8 @@ data class Data(
     val mapY: String,
     val name: String,
     val overview: String,
+    val tel: String?,
+    val homepage: String?,
     val placeId: Long,
     val reviewList: List<ReviewGuestRes>?,
     val subDisability: List<SubDisabilityGuestRes>?

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/detailPlaceGuest/DetailPlaceGuestResponse.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/detailPlaceGuest/DetailPlaceGuestResponse.kt
@@ -23,6 +23,8 @@ data class DetailPlaceGuestResponse(
             longitude = data.mapY,
             name = data.name,
             overview = data.overview,
+            tel = data.tel.orEmpty(),
+            homepage = data.homepage.orEmpty(),
             placeId = data.placeId,
             reviewList = data.reviewList?.map {
                 Review(

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/detailplace/Data.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/detailplace/Data.kt
@@ -16,6 +16,8 @@ data class Data(
     val mapY: String,
     val name: String,
     val overview: String,
+    val tel: String?,
+    val homepage: String?,
     val isReview: Boolean,
     val placeId: Long,
     val reviewList: List<ReviewRes>?,

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/detailplace/DetailPlaceResponse.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/detailplace/DetailPlaceResponse.kt
@@ -24,6 +24,8 @@ data class DetailPlaceResponse(
             longitude = data.mapY,
             name = data.name,
             overview = data.overview,
+            tel = data.tel.orEmpty(),
+            homepage = data.homepage.orEmpty(),
             isReview = data.isReview,
             placeId = data.placeId,
             reviewList = data.reviewList?.map {

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/PlaceDetailInfo.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/PlaceDetailInfo.kt
@@ -12,6 +12,8 @@ data class PlaceDetailInfo (
     val longitude: String,
     val name: String,
     val overview: String,
+    val tel: String,
+    val homepage: String,
     val isReview: Boolean,
     val placeId: Long,
     val reviewList: List<Review>?,

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/PlaceDetailInfoGuest.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/PlaceDetailInfoGuest.kt
@@ -11,6 +11,8 @@ data class PlaceDetailInfoGuest (
     val longitude: String,
     val name: String,
     val overview: String,
+    val tel: String,
+    val homepage: String,
     val placeId: Long,
     val reviewList: List<Review>?,
     val subDisability: List<SubDisability>?

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/place/GetPlaceDetailInfoUseCase.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/place/GetPlaceDetailInfoUseCase.kt
@@ -10,6 +10,11 @@ class GetPlaceDetailInfoUseCase(
 ): BaseUseCase() {
 
     suspend operator fun invoke(placeId: Long): Result<PlaceDetailInfo> = execute {
-        placeRepository.getPlaceDetailInfo(placeId)
+        val placeDetailInfo = placeRepository.getPlaceDetailInfo(placeId)
+
+        val tel = placeDetailInfo.tel.ifEmpty { "문의 정보가 제공되지 않습니다" }
+        val homePage = placeDetailInfo.homepage.ifEmpty { "홈페이지 정보가 제공되지 않습니다" }
+
+        placeDetailInfo.copy(tel = tel, homepage = homePage)
     }
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/home/DetailActivity.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/home/DetailActivity.kt
@@ -1,6 +1,7 @@
 package kr.tekit.lion.daongil.presentation.home
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.activity.viewModels
@@ -120,6 +121,8 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
         name: String,
         address: String,
         overview: String,
+        tel: String,
+        homepage: String,
         image: String?,
         longitude: Double,
         latitude: Double,
@@ -134,18 +137,38 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
 
         settingReviewBtn(placeId, name, address, image)
 
-        binding.detailTitleTv.text = name
-        binding.detailAddressTv.text = address
-        binding.detailBasicContentTv.text = overview
-        binding.detailToolbarTitleTv.text = category
-        binding.detailRouteTv.text = category
+        with(binding) {
+            detailTitleTv.text = name
+            detailAddressTv.text = address
+            detailBasicContentTv.text = overview
+            detailToolbarTitleTv.text = category
+            detailRouteTv.text = category
+            detailBasicAddressContentTv.text = address
+            detailCallContentTv.text = tel
+            detailHomepageContentTv.text = homepage
 
-        if (image != null) {
-            Glide.with(binding.detailThumbnailIv.context)
-                .load(image)
-                .error(R.drawable.empty_view)
-                .into(binding.detailThumbnailIv)
+            detailCallContentTv.setOnClickListener {
+                if (tel != "문의 정보가 제공되지 않습니다") {
+                    val intent = Intent(Intent.ACTION_DIAL)
+                    intent.data = Uri.parse("tel:$tel")
+                    startActivity(intent)
+                }
+            }
+
+            detailHomepageContentTv.setOnClickListener {
+                val url = detailHomepageContentTv.text.toString()
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                startActivity(intent)
+            }
+
+            if (image != null) {
+                Glide.with(detailThumbnailIv.context)
+                    .load(image)
+                    .error(R.drawable.empty_view)
+                    .into(detailThumbnailIv)
+            }
         }
+
 
         val cameraUpdate = CameraUpdate.scrollTo(LatLng(longitude, latitude))
         naverMap.moveCamera(cameraUpdate)
@@ -164,6 +187,8 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
                 detailPlaceInfo.name,
                 detailPlaceInfo.address,
                 detailPlaceInfo.overview,
+                detailPlaceInfo.tel,
+                detailPlaceInfo.homepage,
                 detailPlaceInfo.image,
                 detailPlaceInfo.longitude.toDouble(),
                 detailPlaceInfo.latitude.toDouble(),
@@ -205,6 +230,9 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
         viewModel.getDetailPlaceGuest(placeId)
 
         viewModel.detailPlaceInfoGuest.observe(this@DetailActivity) { detailPlaceInfoGuest ->
+            val tel = detailPlaceInfoGuest.tel ?: "문의 번호 정보가 제공되지 않습니다"
+            val homepage = detailPlaceInfoGuest.homepage ?: "홈페이지 정보가 제공되지 않습니다"
+
             handleCommonDetailPlaceInfo(
                 detailPlaceInfoGuest.placeId,
                 detailPlaceInfoGuest.reviewList,
@@ -212,6 +240,8 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
                 detailPlaceInfoGuest.name,
                 detailPlaceInfoGuest.address,
                 detailPlaceInfoGuest.overview,
+                tel,
+                homepage,
                 detailPlaceInfoGuest.image,
                 detailPlaceInfoGuest.longitude.toDouble(),
                 detailPlaceInfoGuest.latitude.toDouble(),

--- a/DaOnGil/app/src/main/res/layout/activity_detail.xml
+++ b/DaOnGil/app/src/main/res/layout/activity_detail.xml
@@ -154,81 +154,83 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/detail_basic_divider" />
 
-            <!--            <TextView-->
-            <!--                android:id="@+id/detail_basic_address_tv"-->
-            <!--                android:layout_width="wrap_content"-->
-            <!--                android:layout_height="wrap_content"-->
-            <!--                android:layout_marginTop="@dimen/margin_big4"-->
-            <!--                android:fontFamily="@font/pretendard_medium"-->
-            <!--                android:text="주소"-->
-            <!--                android:textColor="@color/text_primary"-->
-            <!--                android:textSize="@dimen/font_small1"-->
-            <!--                app:layout_constraintStart_toStartOf="@+id/detail_basic_content_tv"-->
-            <!--                app:layout_constraintTop_toBottomOf="@+id/detail_basic_content_tv" />-->
+            <TextView
+                android:id="@+id/detail_basic_address_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_big4"
+                android:fontFamily="@font/pretendard_medium"
+                android:text="주소"
+                android:textColor="@color/text_primary"
+                android:textSize="@dimen/font_small1"
+                app:layout_constraintStart_toStartOf="@+id/detail_basic_content_tv"
+                app:layout_constraintTop_toBottomOf="@+id/detail_basic_content_tv" />
 
-            <!--            <TextView-->
-            <!--                android:id="@+id/detail_basic_address_content_tv"-->
-            <!--                android:layout_width="0dp"-->
-            <!--                android:layout_height="wrap_content"-->
-            <!--                android:layout_marginEnd="@dimen/margin_basic"-->
-            <!--                android:fontFamily="@font/pretendard_medium"-->
-            <!--                android:text="주소입니다"-->
-            <!--                android:textColor="@color/text_secondary"-->
-            <!--                android:textSize="@dimen/font_small1"-->
-            <!--                app:layout_constraintEnd_toEndOf="parent"-->
-            <!--                app:layout_constraintStart_toStartOf="@+id/detail_call_content_tv"-->
-            <!--                app:layout_constraintTop_toTopOf="@+id/detail_basic_address_tv" />-->
+            <TextView
+                android:id="@+id/detail_basic_address_content_tv"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/margin_basic"
+                android:fontFamily="@font/pretendard_medium"
+                android:text="주소입니다"
+                android:textColor="@color/text_secondary"
+                android:textSize="@dimen/font_small1"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@+id/detail_call_content_tv"
+                app:layout_constraintTop_toTopOf="@+id/detail_basic_address_tv" />
 
-            <!--            <TextView-->
-            <!--                android:id="@+id/detail_call_tv"-->
-            <!--                android:layout_width="wrap_content"-->
-            <!--                android:layout_height="wrap_content"-->
-            <!--                android:fontFamily="@font/pretendard_medium"-->
-            <!--                android:text="문의"-->
-            <!--                android:textColor="@color/text_primary"-->
-            <!--                android:textSize="@dimen/font_small1"-->
-            <!--                app:layout_constraintStart_toStartOf="@+id/detail_basic_address_tv"-->
-            <!--                app:layout_constraintTop_toTopOf="@+id/detail_call_content_tv" />-->
+            <TextView
+                android:id="@+id/detail_call_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/pretendard_medium"
+                android:text="문의"
+                android:textColor="@color/text_primary"
+                android:textSize="@dimen/font_small1"
+                app:layout_constraintStart_toStartOf="@+id/detail_basic_address_tv"
+                app:layout_constraintTop_toTopOf="@+id/detail_call_content_tv" />
 
-            <!--            <TextView-->
-            <!--                android:id="@+id/detail_call_content_tv"-->
-            <!--                android:layout_width="0dp"-->
-            <!--                android:layout_height="wrap_content"-->
-            <!--                android:layout_marginTop="@dimen/margin_big4"-->
-            <!--                android:layout_marginEnd="@dimen/margin_basic"-->
-            <!--                android:fontFamily="@font/pretendard_medium"-->
-            <!--                android:text="010-1111-1111"-->
-            <!--                android:textColor="@color/text_secondary"-->
-            <!--                android:textSize="@dimen/font_small1"-->
-            <!--                app:layout_constraintEnd_toEndOf="parent"-->
-            <!--                app:layout_constraintStart_toStartOf="@+id/detail_homepage_content_tv"-->
-            <!--                app:layout_constraintTop_toBottomOf="@+id/detail_basic_address_content_tv" />-->
+            <TextView
+                android:id="@+id/detail_call_content_tv"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_big4"
+                android:layout_marginEnd="@dimen/margin_basic"
+                android:autoLink="phone"
+                android:fontFamily="@font/pretendard_medium"
+                android:text="010-1111-1111"
+                android:textColor="@color/text_secondary"
+                android:textSize="@dimen/font_small1"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@+id/detail_homepage_content_tv"
+                app:layout_constraintTop_toBottomOf="@+id/detail_basic_address_content_tv" />
 
-            <!--            <TextView-->
-            <!--                android:id="@+id/detail_homepage_tv"-->
-            <!--                android:layout_width="wrap_content"-->
-            <!--                android:layout_height="wrap_content"-->
-            <!--                android:fontFamily="@font/pretendard_medium"-->
-            <!--                android:text="홈페이지"-->
-            <!--                android:textColor="@color/text_primary"-->
-            <!--                android:textSize="@dimen/font_small1"-->
-            <!--                app:layout_constraintStart_toStartOf="@id/detail_call_tv"-->
-            <!--                app:layout_constraintTop_toTopOf="@+id/detail_homepage_content_tv" />-->
+            <TextView
+                android:id="@+id/detail_homepage_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/pretendard_medium"
+                android:text="홈페이지"
+                android:textColor="@color/text_primary"
+                android:textSize="@dimen/font_small1"
+                app:layout_constraintStart_toStartOf="@id/detail_call_tv"
+                app:layout_constraintTop_toTopOf="@+id/detail_homepage_content_tv" />
 
-            <!--            <TextView-->
-            <!--                android:id="@+id/detail_homepage_content_tv"-->
-            <!--                android:layout_width="0dp"-->
-            <!--                android:layout_height="wrap_content"-->
-            <!--                android:layout_marginStart="@dimen/margin_big4"-->
-            <!--                android:layout_marginTop="@dimen/margin_big4"-->
-            <!--                android:layout_marginEnd="@dimen/margin_basic"-->
-            <!--                android:fontFamily="@font/pretendard_medium"-->
-            <!--                android:text="홈페이지 주소"-->
-            <!--                android:textColor="@color/text_secondary"-->
-            <!--                android:textSize="@dimen/font_small1"-->
-            <!--                app:layout_constraintEnd_toEndOf="parent"-->
-            <!--                app:layout_constraintStart_toEndOf="@+id/detail_homepage_tv"-->
-            <!--                app:layout_constraintTop_toBottomOf="@+id/detail_call_content_tv" />-->
+            <TextView
+                android:id="@+id/detail_homepage_content_tv"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_big4"
+                android:layout_marginTop="@dimen/margin_big4"
+                android:layout_marginEnd="@dimen/margin_basic"
+                android:autoLink="web"
+                android:fontFamily="@font/pretendard_medium"
+                android:text="홈페이지 주소"
+                android:textColor="@color/text_secondary"
+                android:textSize="@dimen/font_small1"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/detail_homepage_tv"
+                app:layout_constraintTop_toBottomOf="@+id/detail_call_content_tv" />
 
             <TextView
                 android:id="@+id/detail_service_title_tv"
@@ -239,8 +241,8 @@
                 android:text="무장애 편의정보"
                 android:textColor="@color/text_secondary"
                 android:textSize="@dimen/font_big2"
-                app:layout_constraintStart_toStartOf="@id/detail_basic_content_tv"
-                app:layout_constraintTop_toBottomOf="@id/detail_basic_content_tv" />
+                app:layout_constraintStart_toStartOf="@id/detail_homepage_tv"
+                app:layout_constraintTop_toBottomOf="@id/detail_homepage_content_tv" />
 
             <com.google.android.material.divider.MaterialDivider
                 android:id="@+id/detail_service_divider"
@@ -345,13 +347,13 @@
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="@dimen/margin_basic"
                 android:backgroundTint="@color/background_color"
-                android:text="수정하기"
                 android:fontFamily="@font/pretendard_semibold"
+                android:text="수정하기"
                 android:textColor="@color/text_secondary"
                 android:textSize="@dimen/font_small1"
                 app:layout_constraintBottom_toBottomOf="@+id/detail_review_tv"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/detail_review_tv"/>
+                app:layout_constraintTop_toTopOf="@+id/detail_review_tv" />
 
             <com.google.android.material.divider.MaterialDivider
                 android:id="@+id/detail_review_divider"


### PR DESCRIPTION
## #️⃣연관된 이슈

- #230 

## 📝작업 내용

- 관광지 상세보기 화면에서 전화번호, 홈페이지 데이터 추가
- 추가된 데이터 관련 UI 추가
- 전화번호 클릭 시 다이얼로그로 이동 / 홈페이지 Url 클릭시 해당 화면으로 이동
- 전화번호/홈페이지 null 데이터 시 "해당 정보 없음" 처리

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
- 데이터가 없을 경우 "해당 정보가 제공되지 않습니다" 처리
<img src="https://github.com/user-attachments/assets/655c47b9-d272-4543-a4bd-9638126c4365" width="40%" height="40%"/>

https://github.com/user-attachments/assets/58a1dbcc-5fa9-494f-b954-ce9f4045d58f



## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - 전화번호, 홈페이지 데이터가 제공될 때 클릭 시 다이얼로그 / 해당 url로 이동하면 좋을 것 같아서 추가해 두었습니다
  - 전화번호, 홈페이지 데이터가 null로 올 때 에러 처리가 아니라 "해당 정보가 제공되지 않습니다" 문구로 바꿔서 넣어주고 싶어서
  이 부분을 repositoryImpl / dataSource / UseCase 중 어디에서 처리를 해주는 게 좋을지 고민을 해보았는데 (with 찬호오빠)
  저는 아래와 같은 이유로 UseCase에서 처리해주는 게 좋을 것 같아서 일단 UseCase에서 처리해주는 방향으로 구현해 두었습니다
  
    1. 데이터 레이어에서는 어떤 데이터를 뽑아올 것인지 결정하고, 도메인 레이어에서는 뽑아온 데이터에 후처리를 해준다
       이때 tel, hompage 데이터를 뽑아오는 것까지가 데이터 레이어의 역할이고, null에 대한 처리는 데이터에 대한 후처리이니 도메인 레이어에서 해줘야 할 것 같다
    2. 굳이 따져보자면 null을 "~"과 같은 메세지로 바꿔주는 것은 사용자에게 정확한 정보를 제공하기 위함이기 때문에 비즈니스 로직에 해당하지 않을까..?
    3. 에러 처리가 아니라 데이터 변환이니 유즈케이스에서 변환해주는 것이 좋을 것 같다

  -  찬호오빠랑 해당 부분에 대해 얘기를 나눠보면서 찬호오빠는 repositoryImpl에서 처리하는 게 좋을 것 같다는 의견이였는데
     일단 저의 고민 결과는 위와 같은 이유로 UseCase에서 구현해두었습니다 !
     나중에 UseCase를 안 쓰게 되면 또 수정을 해야하겠지만 일단은 ..ㅎㅎ

  - 아직은 몇줄 안되는 코드에 대한 처리긴 하지만 클린 아키텍처에 대해 또 다시 생각해 보게 된 부분인 것 같아서 남겨봤습니다 ㅎㅎ
    혹시 다른 의견이 있으시면 남겨주세용 같이 고민해 보면 좋을 것 같네요 ! 🤔
