### PR TITLE
[#251] 본인 일정 상세보기 관련 기능 연결

### DIFF
--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/datasource/PlanDataSource.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/datasource/PlanDataSource.kt
@@ -76,4 +76,8 @@ class PlanDataSource(
     suspend fun deleteMyPlanReview(reviewId: Long) {
         return planService.deleteMyPlanReview(reviewId)
     }
+
+    suspend fun updateMyPlanPublic(planId: Long) {
+        return planService.updateMyPlanPublic(planId)
+    }
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/datasource/PlanDataSource.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/datasource/PlanDataSource.kt
@@ -80,4 +80,8 @@ class PlanDataSource(
     suspend fun updateMyPlanPublic(planId: Long) {
         return planService.updateMyPlanPublic(planId)
     }
+
+    suspend fun deleteMyPlanSchedule(planId: Long) {
+        return planService.deleteMyPlanSchedule(planId)
+    }
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/plan/scheduleDetail/ScheduleDetailResponse.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/plan/scheduleDetail/ScheduleDetailResponse.kt
@@ -1,15 +1,15 @@
 package kr.tekit.lion.daongil.data.dto.remote.response.plan.scheduleDetail
 
-import kr.tekit.lion.daongil.domain.model.ScheduleDetailnfo
+import kr.tekit.lion.daongil.domain.model.ScheduleDetailInfo
 
 data class ScheduleDetailResponse(
     val code: Int,
     val data: Data,
     val message: String
 ) {
-    fun toDomainModel(): ScheduleDetailnfo {
+    fun toDomainModel(): ScheduleDetailInfo {
         return data.let{
-            ScheduleDetailnfo(
+            ScheduleDetailInfo(
                 title = it.title,
                 startDate = it.startDate,
                 endDate = it.endDate,

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/service/PlanService.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/service/PlanService.kt
@@ -124,4 +124,10 @@ interface PlanService {
     suspend fun updateMyPlanPublic(
         @Path("planId") planId: Long
     )
+
+    // 여행 일정 삭제
+    @DELETE("plan/{planId}")
+    suspend fun deleteMyPlanSchedule(
+        @Path("planId") planId: Long
+    )
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/service/PlanService.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/service/PlanService.kt
@@ -15,6 +15,7 @@ import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Multipart
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Part
 import retrofit2.http.Path
@@ -116,5 +117,11 @@ interface PlanService {
     @DELETE("plan/review/{reviewId}")
     suspend fun deleteMyPlanReview(
         @Path("reviewId") reviewId: Long
+    )
+
+    // 일정 공개 비공개 수정
+    @PATCH("plan/{planId}/ispublic")
+    suspend fun updateMyPlanPublic(
+        @Path("planId") planId: Long
     )
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/repository/PlanRepositoryImpl.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/repository/PlanRepositoryImpl.kt
@@ -12,7 +12,7 @@ import kr.tekit.lion.daongil.domain.model.NewScheduleReview
 import kr.tekit.lion.daongil.domain.model.OpenPlan
 import kr.tekit.lion.daongil.domain.model.PlaceSearchResult
 import kr.tekit.lion.daongil.domain.model.ReviewImg
-import kr.tekit.lion.daongil.domain.model.ScheduleDetailnfo
+import kr.tekit.lion.daongil.domain.model.ScheduleDetailInfo
 import kr.tekit.lion.daongil.domain.model.ScheduleDetailReview
 import kr.tekit.lion.daongil.domain.repository.PlanRepository
 
@@ -61,12 +61,12 @@ class PlanRepositoryImpl(
         return planDataSource.getMyElapsedScheduleList(size, page).toDomainModel()
     }
 
-    override suspend fun getDetailScheduleInfo(planId: Long): ScheduleDetailnfo {
+    override suspend fun getDetailScheduleInfo(planId: Long): ScheduleDetailInfo {
 
         return planDataSource.getDetailScheduleInfo(planId).toDomainModel()
     }
 
-    override suspend fun getDetailScheduleInfoGuest(plandId: Long): ScheduleDetailnfo {
+    override suspend fun getDetailScheduleInfoGuest(plandId: Long): ScheduleDetailInfo {
         return planDataSource.getDetailScheduleInfoGuest(plandId).toDomainModel()
     }
 
@@ -80,5 +80,9 @@ class PlanRepositoryImpl(
 
     override suspend fun deleteMyPlanReview(reviewId: Long) {
         return planDataSource.deleteMyPlanReview(reviewId)
+    }
+
+    override suspend fun updateMyPlanPublic(planId: Long) {
+        return planDataSource.updateMyPlanPublic(planId)
     }
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/repository/PlanRepositoryImpl.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/repository/PlanRepositoryImpl.kt
@@ -85,4 +85,8 @@ class PlanRepositoryImpl(
     override suspend fun updateMyPlanPublic(planId: Long) {
         return planDataSource.updateMyPlanPublic(planId)
     }
+
+    override suspend fun deleteMyPlanSchedule(planId: Long) {
+        return planDataSource.deleteMyPlanSchedule(planId)
+    }
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/ScheduleDetailInfo.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/ScheduleDetailInfo.kt
@@ -1,6 +1,6 @@
 package kr.tekit.lion.daongil.domain.model
 
-data class ScheduleDetailnfo (
+data class ScheduleDetailInfo (
     val title : String,
     val startDate : String,
     val endDate : String,

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/repository/PlanRepository.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/repository/PlanRepository.kt
@@ -13,7 +13,7 @@ import kr.tekit.lion.daongil.domain.model.NewScheduleReview
 import kr.tekit.lion.daongil.domain.model.OpenPlan
 import kr.tekit.lion.daongil.domain.model.PlaceSearchResult
 import kr.tekit.lion.daongil.domain.model.ReviewImg
-import kr.tekit.lion.daongil.domain.model.ScheduleDetailnfo
+import kr.tekit.lion.daongil.domain.model.ScheduleDetailInfo
 import kr.tekit.lion.daongil.domain.model.ScheduleDetailReview
 
 interface PlanRepository {
@@ -38,15 +38,17 @@ interface PlanRepository {
 
     suspend fun getMyElapsedScheduleList(size: Int, page: Int): MyElapsedSchedules
 
-    suspend fun getDetailScheduleInfo(planId: Long): ScheduleDetailnfo
+    suspend fun getDetailScheduleInfo(planId: Long): ScheduleDetailInfo
 
-    suspend fun getDetailScheduleInfoGuest(plandId: Long): ScheduleDetailnfo
+    suspend fun getDetailScheduleInfoGuest(plandId: Long): ScheduleDetailInfo
 
     suspend fun getDetailScheduleReview(planId: Long): ScheduleDetailReview
 
     suspend fun getDetailScheduleReviewGuest(planId: Long): ScheduleDetailReview
 
     suspend fun deleteMyPlanReview(reviewId: Long)
+
+    suspend fun updateMyPlanPublic(planId: Long)
 
     companion object{
         fun create(): PlanRepositoryImpl{

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/repository/PlanRepository.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/repository/PlanRepository.kt
@@ -50,6 +50,8 @@ interface PlanRepository {
 
     suspend fun updateMyPlanPublic(planId: Long)
 
+    suspend fun deleteMyPlanSchedule(planId: Long)
+
     companion object{
         fun create(): PlanRepositoryImpl{
             return PlanRepositoryImpl(

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/plan/DeleteMyPlanScheduleUseCase.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/plan/DeleteMyPlanScheduleUseCase.kt
@@ -1,0 +1,13 @@
+package kr.tekit.lion.daongil.domain.usecase.plan
+
+import kr.tekit.lion.daongil.domain.repository.PlanRepository
+import kr.tekit.lion.daongil.domain.usecase.base.BaseUseCase
+import kr.tekit.lion.daongil.domain.usecase.base.Result
+
+class DeleteMyPlanScheduleUseCase(
+    private val planRepository: PlanRepository
+): BaseUseCase() {
+    suspend operator fun invoke(planId: Long): Result<Unit> = execute {
+        planRepository.deleteMyPlanSchedule(planId)
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/plan/GetScheduleDetailGuestUsecase.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/plan/GetScheduleDetailGuestUsecase.kt
@@ -2,7 +2,7 @@ package kr.tekit.lion.daongil.domain.usecase.plan
 
 import kr.tekit.lion.daongil.domain.model.ScheduleDetail
 import kr.tekit.lion.daongil.domain.model.ScheduleDetailReview
-import kr.tekit.lion.daongil.domain.model.ScheduleDetailnfo
+import kr.tekit.lion.daongil.domain.model.ScheduleDetailInfo
 import kr.tekit.lion.daongil.domain.repository.PlanRepository
 import kr.tekit.lion.daongil.domain.usecase.base.BaseUseCase
 import kr.tekit.lion.daongil.domain.usecase.base.Result
@@ -21,7 +21,7 @@ class GetScheduleDetailGuestUsecase(
 
 
 private fun combineScheduleDetail(
-    info: ScheduleDetailnfo,
+    info: ScheduleDetailInfo,
     review: ScheduleDetailReview
 ): ScheduleDetail {
     return ScheduleDetail(

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/plan/GetScheduleDetailUseCase.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/plan/GetScheduleDetailUseCase.kt
@@ -1,7 +1,7 @@
 package kr.tekit.lion.daongil.domain.usecase.plan
 
 import kr.tekit.lion.daongil.domain.model.ScheduleDetail
-import kr.tekit.lion.daongil.domain.model.ScheduleDetailnfo
+import kr.tekit.lion.daongil.domain.model.ScheduleDetailInfo
 import kr.tekit.lion.daongil.domain.model.ScheduleDetailReview
 import kr.tekit.lion.daongil.domain.repository.PlanRepository
 import kr.tekit.lion.daongil.domain.usecase.base.BaseUseCase
@@ -22,7 +22,7 @@ class GetScheduleDetailUseCase(
 
 
 private fun combineScheduleDetail(
-    info: ScheduleDetailnfo,
+    info: ScheduleDetailInfo,
     review: ScheduleDetailReview
 ): ScheduleDetail {
     return ScheduleDetail(

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/plan/UpdateMyPlanPublicUseCase.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/plan/UpdateMyPlanPublicUseCase.kt
@@ -1,0 +1,15 @@
+package kr.tekit.lion.daongil.domain.usecase.plan
+
+import kr.tekit.lion.daongil.domain.model.ScheduleDetailInfo
+import kr.tekit.lion.daongil.domain.repository.PlanRepository
+import kr.tekit.lion.daongil.domain.usecase.base.BaseUseCase
+import kr.tekit.lion.daongil.domain.usecase.base.Result
+
+class UpdateMyPlanPublicUseCase(
+    private val planRepository: PlanRepository
+): BaseUseCase() {
+    suspend operator fun invoke(planId: Long): Result<ScheduleDetailInfo> = execute {
+        planRepository.updateMyPlanPublic(planId)
+        planRepository.getDetailScheduleInfo(planId)
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/ScheduleMainFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/ScheduleMainFragment.kt
@@ -65,13 +65,16 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main), ConfirmD
 
     private val scheduleDetailLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
         if (result.resultCode == Activity.RESULT_OK) {
-            viewModel.getMyMainPlanList()
-            viewModel.getOpenPlanList(6, 0)
             view?.let {
                 Snackbar.make(it, "일정이 삭제되었습니다.", Snackbar.LENGTH_LONG)
                     .setBackgroundTint(ContextCompat.getColor(requireActivity(), R.color.text_secondary))
                     .show()
             }
+            viewModel.getMyMainPlanList()
+            viewModel.getOpenPlanList(6, 0)
+        } else {
+            viewModel.getMyMainPlanList()
+            viewModel.getOpenPlanList(6, 0)
         }
     }
 
@@ -86,6 +89,7 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main), ConfirmD
         initNewScheduleButton(binding)
 
         initMoreViewClickListener(binding)
+        viewModel.getOpenPlanList(6, 0)
 
         repeatOnStarted {
             viewModel.loginState.collect { uiState ->

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/ScheduleMainFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/fragment/ScheduleMainFragment.kt
@@ -41,6 +41,8 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main), ConfirmD
 
     private val scheduleReviewLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
         if (result.resultCode == Activity.RESULT_OK) {
+            viewModel.getMyMainPlanList()
+            viewModel.getOpenPlanList(6, 0)
             view?.let {
                 Snackbar.make(it, "후기가 저장되었습니다", Snackbar.LENGTH_LONG)
                     .setBackgroundTint(ContextCompat.getColor(requireActivity(), R.color.text_secondary))
@@ -51,6 +53,8 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main), ConfirmD
 
     private val scheduleFormLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()){ result ->
         if (result.resultCode == Activity.RESULT_OK) {
+            viewModel.getMyMainPlanList()
+            viewModel.getOpenPlanList(6, 0)
             view?.let{
                 Snackbar.make(it, "일정이 저장되었습니다", Snackbar.LENGTH_LONG)
                     .setBackgroundTint(ContextCompat.getColor(requireActivity(), R.color.text_secondary))
@@ -59,18 +63,25 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main), ConfirmD
         }
     }
 
-    override fun onResume() {
-        super.onResume()
-
-        viewModel.getMyMainPlanList()
+    private val scheduleDetailLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            viewModel.getMyMainPlanList()
+            viewModel.getOpenPlanList(6, 0)
+            view?.let {
+                Snackbar.make(it, "일정이 삭제되었습니다.", Snackbar.LENGTH_LONG)
+                    .setBackgroundTint(ContextCompat.getColor(requireActivity(), R.color.text_secondary))
+                    .show()
+            }
+        }
     }
+
+
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         val binding = FragmentScheduleMainBinding.bind(view)
 
-        // initView(binding)
         settingRecyclerView(binding)
         initNewScheduleButton(binding)
 
@@ -99,17 +110,6 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main), ConfirmD
 
     }
 
-    /*private fun initView(binding: FragmentScheduleMainBinding) {
-        if (isUser) {
-            // 회원의 일정 정보를 불러온다
-            viewModel.getMyMainPlanList()
-        } else { // 비회원
-            binding.textViewMyScheduleMore.visibility = View.INVISIBLE
-            displayAddSchedulePrompt(binding)
-        }
-    }*/
-
-
     private fun settingRecyclerView(binding: FragmentScheduleMainBinding) {
 
         with(binding) {
@@ -125,7 +125,6 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main), ConfirmD
                 recyclerViewMySchedule.apply {
                     val myscheduleAdapter = ScheduleMyAdapter(
                         itemClickListener = { position ->
-                            val intent = Intent(requireActivity(), ScheduleDetailActivity::class.java)
                             // to do - 여행 일정 idx 전달
                             val planId = it[position]?.planId
                             planId?.let {
@@ -151,7 +150,6 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main), ConfirmD
                 viewModel.openPlanList.observe(viewLifecycleOwner) {
                     val schedulePublicAdapter = SchedulePublicAdapter(
                         itemClickListener = { position ->
-                          val intent = Intent(requireActivity(), ScheduleDetailActivity::class.java)
                             // to do - 여행 일정 idx 전달
                             val planId = it[position]?.planId
                             planId?.let {
@@ -232,7 +230,7 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main), ConfirmD
     private fun initScheduleDetailActivity(planId: Long){
         val intent = Intent(requireActivity(), ScheduleDetailActivity::class.java)
         intent.putExtra("planId", planId)
-        startActivity(intent)
+        scheduleDetailLauncher.launch(intent)
     }
 
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/vm/ScheduleMainViewModel.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/vm/ScheduleMainViewModel.kt
@@ -31,7 +31,6 @@ class ScheduleMainViewModel(
     val loginState = _loginState.asStateFlow()
 
     init {
-        getOpenPlanList(6, 0)
         checkLoginState()
     }
 

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/vm/ScheduleMainViewModel.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/main/vm/ScheduleMainViewModel.kt
@@ -31,7 +31,7 @@ class ScheduleMainViewModel(
     val loginState = _loginState.asStateFlow()
 
     init {
-        getOpenPlanList(5, 0)
+        getOpenPlanList(6, 0)
         checkLoginState()
     }
 

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/ResultCode.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/ResultCode.kt
@@ -1,0 +1,7 @@
+package kr.tekit.lion.daongil.presentation.schedule
+
+object ResultCode {
+    const val RESULT_REVIEW_WRITE = 1
+    const val RESULT_SCHEDULE_EDIT = 2
+    const val RESULT_REVIEW_EDIT = 3
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/ScheduleDetailActivity.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/ScheduleDetailActivity.kt
@@ -24,6 +24,8 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import kr.tekit.lion.daongil.domain.model.ScheduleDetail
 import kr.tekit.lion.daongil.presentation.ext.repeatOnStarted
@@ -31,6 +33,10 @@ import kr.tekit.lion.daongil.presentation.ext.setImage
 import kr.tekit.lion.daongil.presentation.home.DetailActivity
 import kr.tekit.lion.daongil.presentation.login.LogInState
 import kr.tekit.lion.daongil.presentation.login.LoginActivity
+import kr.tekit.lion.daongil.presentation.schedule.ResultCode.RESULT_REVIEW_EDIT
+import kr.tekit.lion.daongil.presentation.schedule.ResultCode.RESULT_REVIEW_WRITE
+import kr.tekit.lion.daongil.presentation.schedule.ResultCode.RESULT_SCHEDULE_EDIT
+import kr.tekit.lion.daongil.presentation.schedulereview.ModifyScheduleReviewActivity
 import kr.tekit.lion.daongil.presentation.schedulereview.WriteScheduleReviewActivity
 import java.util.Timer
 import kotlin.concurrent.scheduleAtFixedRate
@@ -56,6 +62,29 @@ class ScheduleDetailActivity : AppCompatActivity(), ConfirmDialogInterface {
     private val binding: ActivityScheduleBinding by lazy {
         ActivityScheduleBinding.inflate(layoutInflater)
     }
+
+    private val scheduleReviewLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+        val planId = intent.getLongExtra("planId", -1)
+        viewModel.getScheduleDetailInfo(planId)
+        when(result.resultCode){
+            RESULT_REVIEW_WRITE -> {
+                Snackbar.make(binding.root, "후기가 저장되었습니다", Snackbar.LENGTH_LONG)
+                    .setBackgroundTint(ContextCompat.getColor(this, R.color.text_secondary))
+                    .show()
+            }
+            RESULT_SCHEDULE_EDIT -> {
+                Snackbar.make(binding.root, "일정이 수정되었습니다", Snackbar.LENGTH_LONG)
+                    .setBackgroundTint(ContextCompat.getColor(this, R.color.text_secondary))
+                    .show()
+            }
+            RESULT_REVIEW_EDIT -> {
+                Snackbar.make(binding.root, "리뷰가 수정되었습니다", Snackbar.LENGTH_LONG)
+                    .setBackgroundTint(ContextCompat.getColor(this, R.color.text_secondary))
+                    .show()
+            }
+        }
+    }
+
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -89,13 +118,6 @@ class ScheduleDetailActivity : AppCompatActivity(), ConfirmDialogInterface {
                     if(scheduleDetail.isWriter){
                         this.scheduleEmptyReviewTitle.text = getString(R.string.text_schedule_info_writer_not_leave_title)
                         this.scheduleEmptyReviewContent.text = getString(R.string.text_schedule_info_writer_not_leave_content)
-                        cardViewScheduleEmptyReview.setOnClickListener {
-                            val newIntent =
-                                Intent(this@ScheduleDetailActivity, WriteScheduleReviewActivity::class.java)
-                            val planId = intent.getLongExtra("planId", -1)
-                            newIntent.putExtra("planId", planId)
-                            startActivity(newIntent)
-                        }
                     }
                     // 지나가지 않은 일정 + 내가 작성자가 아님
                     else{
@@ -116,6 +138,7 @@ class ScheduleDetailActivity : AppCompatActivity(), ConfirmDialogInterface {
                         }
 
                         cardViewScheduleReview.visibility = View.VISIBLE
+                        cardViewScheduleEmptyReview.visibility = View.GONE
                         this@ScheduleDetailActivity.setImage(ivProfileImage, scheduleDetail.profileUrl)
                         textNickname.text = scheduleDetail.nickname
                         ratingBarScheduleSatisfaction.rating = scheduleDetail.grade?.toFloat() ?: 0F
@@ -178,7 +201,7 @@ class ScheduleDetailActivity : AppCompatActivity(), ConfirmDialogInterface {
                                     Intent(this@ScheduleDetailActivity, WriteScheduleReviewActivity::class.java)
                                 val planId = intent.getLongExtra("planId", -1)
                                 newIntent.putExtra("planId", planId)
-                                startActivity(newIntent)
+                                scheduleReviewLauncher.launch(newIntent)
                             }
                         }
                         else {
@@ -270,8 +293,11 @@ class ScheduleDetailActivity : AppCompatActivity(), ConfirmDialogInterface {
     }
 
     private fun initToolbarMenu(isUser: Boolean, isWriter: Boolean, isPublic: Boolean) {
+
         binding.toolbarViewSchedule.apply {
+            menu.clear()
             setNavigationOnClickListener {
+                setResult(Activity.RESULT_CANCELED)
                 finish()
             }
             if (isWriter) { // 로그인한 사용자의 일정인 경우
@@ -413,24 +439,33 @@ class ScheduleDetailActivity : AppCompatActivity(), ConfirmDialogInterface {
                 viewModel.deleteMyPlanSchedule(planId)
                 setResult(Activity.RESULT_OK)
                 finish()
+            },
+            onScheduleEditClickListener = {
+                // 일정 수정 activity로
             }).show(supportFragmentManager, "ScheduleManageBottomSheet")
     }
 
     private fun showScheduleReviewManageBottomSheet(planId: Long, reviewId: Long) {
-        ScheduleReviewManageBottomSheet(planId) {
-            // TO DO - 서버에 여행 일정 후기 삭제 요청
-            viewModel.deleteMyPlanReview(
-                reviewId = reviewId,
-                planId = planId
-            )
-            // TO DO - 이 화면에서 관리하고 있는 일정정보 data에도 후기 값 업데이트? (보류)
-            /*binding.cardViewScheduleReview.visibility = View.GONE
-            binding.cardViewScheduleEmptyReview.visibility = View.VISIBLE*/
-            showSnackBar(
-                binding.imageButtonScheduleManageReview,
-                R.string.text_schedule_review_deleted,
-            )
-        }.show(supportFragmentManager, "ScheduleReviewManageBottomSheet")
+        ScheduleReviewManageBottomSheet(
+            reviewId = planId,
+            onReviewDeleteClickListener = {
+                // TO DO - 서버에 여행 일정 후기 삭제 요청
+                viewModel.deleteMyPlanReview(
+                    reviewId = reviewId,
+                    planId = planId
+                )
+                showSnackBar(
+                    binding.imageButtonScheduleManageReview,
+                    R.string.text_schedule_review_deleted,
+                )
+            },
+            onReviewEditClickListener = {
+                // 리뷰 수정 activity
+                val newIntent =
+                    Intent(this@ScheduleDetailActivity, ModifyScheduleReviewActivity::class.java)
+                newIntent.putExtra("reviewId", reviewId)
+                scheduleReviewLauncher.launch(newIntent)
+            }).show(supportFragmentManager, "ScheduleReviewManageBottomSheet")
     }
 
     private fun showSnackBar(view: View, message: Int) {

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/ScheduleDetailActivity.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/ScheduleDetailActivity.kt
@@ -381,10 +381,12 @@ class ScheduleDetailActivity : AppCompatActivity(), ConfirmDialogInterface {
         ScheduleManageBottomSheet(isPublic) {
             // 공개/비공개 상태 Toggle Listener
             // 공개 -> 비공개
+            val planId = intent.getLongExtra("planId", -1)
+            viewModel.updateMyPlanPublic(planId)
             if (isPublic) {
                 // TO DO - 서버에 비공개 상태로 변경 요청
                 // TO DO - isPublic 값 업데이트 (이건 어떤 식으로 관리하면 좋을지.. 데이터 연결 후 살펴볼 것)
-                binding.textViewScheduleType.text = getString(R.string.text_schedule_private)
+                // binding.textViewScheduleType.text = getString(R.string.text_schedule_private)
                 showSnackBar(
                     binding.cardViewScheduleReview,
                     R.string.text_schedule_changed_to_private
@@ -394,7 +396,7 @@ class ScheduleDetailActivity : AppCompatActivity(), ConfirmDialogInterface {
             else {
                 // TO DO - 서버에 공개 상태로 변경 요청
                 // TO DO - isPublic 값 업데이트 (이건 어떤 식으로 관리하면 좋을지.. 데이터 연결 후 살펴볼 것)
-                binding.textViewScheduleType.text = getString(R.string.text_schedule_public)
+                // binding.textViewScheduleType.text = getString(R.string.text_schedule_public)
                 showSnackBar(
                     binding.cardViewScheduleReview,
                     R.string.text_schedule_changed_to_public

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/ScheduleDetailActivity.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/ScheduleDetailActivity.kt
@@ -1,5 +1,6 @@
 package kr.tekit.lion.daongil.presentation.schedule
 
+import android.app.Activity
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
@@ -378,31 +379,41 @@ class ScheduleDetailActivity : AppCompatActivity(), ConfirmDialogInterface {
     }
 
     private fun showScheduleManageBottomSheet(isPublic: Boolean) {
-        ScheduleManageBottomSheet(isPublic) {
-            // 공개/비공개 상태 Toggle Listener
-            // 공개 -> 비공개
-            val planId = intent.getLongExtra("planId", -1)
-            viewModel.updateMyPlanPublic(planId)
-            if (isPublic) {
-                // TO DO - 서버에 비공개 상태로 변경 요청
-                // TO DO - isPublic 값 업데이트 (이건 어떤 식으로 관리하면 좋을지.. 데이터 연결 후 살펴볼 것)
-                // binding.textViewScheduleType.text = getString(R.string.text_schedule_private)
-                showSnackBar(
-                    binding.cardViewScheduleReview,
-                    R.string.text_schedule_changed_to_private
-                )
-            }
-            // 비공개 -> 공개
-            else {
-                // TO DO - 서버에 공개 상태로 변경 요청
-                // TO DO - isPublic 값 업데이트 (이건 어떤 식으로 관리하면 좋을지.. 데이터 연결 후 살펴볼 것)
-                // binding.textViewScheduleType.text = getString(R.string.text_schedule_public)
-                showSnackBar(
-                    binding.cardViewScheduleReview,
-                    R.string.text_schedule_changed_to_public
-                )
-            }
-        }.show(supportFragmentManager, "ScheduleManageBottomSheet")
+
+        val planId = intent.getLongExtra("planId", -1)
+
+        ScheduleManageBottomSheet(
+            isPublic = isPublic,
+            onScheduleStateToggleListener = {
+                // 공개/비공개 상태 Toggle Listener
+                // 공개 -> 비공개
+
+                viewModel.updateMyPlanPublic(planId)
+                if (isPublic) {
+                    // TO DO - 서버에 비공개 상태로 변경 요청
+                    // TO DO - isPublic 값 업데이트 (이건 어떤 식으로 관리하면 좋을지.. 데이터 연결 후 살펴볼 것)
+                    // binding.textViewScheduleType.text = getString(R.string.text_schedule_private)
+                    showSnackBar(
+                        binding.cardViewScheduleReview,
+                        R.string.text_schedule_changed_to_private
+                    )
+                }
+                // 비공개 -> 공개
+                else {
+                    // TO DO - 서버에 공개 상태로 변경 요청
+                    // TO DO - isPublic 값 업데이트 (이건 어떤 식으로 관리하면 좋을지.. 데이터 연결 후 살펴볼 것)
+                    // binding.textViewScheduleType.text = getString(R.string.text_schedule_public)
+                    showSnackBar(
+                        binding.cardViewScheduleReview,
+                        R.string.text_schedule_changed_to_public
+                    )
+                }
+            },
+            onScheduleDeleteClickListener = {
+                viewModel.deleteMyPlanSchedule(planId)
+                setResult(Activity.RESULT_OK)
+                finish()
+            }).show(supportFragmentManager, "ScheduleManageBottomSheet")
     }
 
     private fun showScheduleReviewManageBottomSheet(planId: Long, reviewId: Long) {
@@ -412,7 +423,6 @@ class ScheduleDetailActivity : AppCompatActivity(), ConfirmDialogInterface {
                 reviewId = reviewId,
                 planId = planId
             )
-
             // TO DO - 이 화면에서 관리하고 있는 일정정보 data에도 후기 값 업데이트? (보류)
             /*binding.cardViewScheduleReview.visibility = View.GONE
             binding.cardViewScheduleEmptyReview.visibility = View.VISIBLE*/

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/customview/ScheduleManageBottomSheet.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/customview/ScheduleManageBottomSheet.kt
@@ -10,7 +10,8 @@ import kr.tekit.lion.daongil.presentation.main.dialog.ConfirmDialogInterface
 
 class ScheduleManageBottomSheet(
     private val isPublic:Boolean,
-    private val onScheuldeStateToggleListener: () -> Unit
+    private val onScheduleStateToggleListener: () -> Unit,
+    private val onScheduleDeleteClickListener: () -> Unit
 ) : BottomSheetDialogFragment(R.layout.bottom_sheet_schedule_manage),
 
     ConfirmDialogInterface {
@@ -44,7 +45,7 @@ class ScheduleManageBottomSheet(
             }
 
             layoutScheduleManagePublicToggle.setOnClickListener {
-                onScheuldeStateToggleListener()
+                onScheduleStateToggleListener()
                 dismiss()
             }
 
@@ -55,7 +56,7 @@ class ScheduleManageBottomSheet(
         val dialog = ConfirmDialog(
             this,
             "여행 일정 삭제",
-            "삭제한 데이터는 되돌릴 수 없습니다.",
+            "삭제한 일정은 되돌릴 수 없습니다.",
             "삭제하기",
             R.color.button_tertiary,
             R.color.white
@@ -66,7 +67,8 @@ class ScheduleManageBottomSheet(
 
     override fun onPosBtnClick() {
         // TO DO 서버 데이터 삭제 요청
-        requireActivity().finish()
+        onScheduleDeleteClickListener()
+        dismiss()
     }
 
     override fun getTheme(): Int {

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/customview/ScheduleManageBottomSheet.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/customview/ScheduleManageBottomSheet.kt
@@ -11,7 +11,8 @@ import kr.tekit.lion.daongil.presentation.main.dialog.ConfirmDialogInterface
 class ScheduleManageBottomSheet(
     private val isPublic:Boolean,
     private val onScheduleStateToggleListener: () -> Unit,
-    private val onScheduleDeleteClickListener: () -> Unit
+    private val onScheduleDeleteClickListener: () -> Unit,
+    private val onScheduleEditClickListener: () -> Unit
 ) : BottomSheetDialogFragment(R.layout.bottom_sheet_schedule_manage),
 
     ConfirmDialogInterface {
@@ -38,7 +39,7 @@ class ScheduleManageBottomSheet(
             }
 
             layoutScheduleManageEdit.setOnClickListener {
-                // TO DO 일정 수정 화면으로
+                onScheduleEditClickListener()
             }
             layoutScheduleManageDelete.setOnClickListener {
                 showScheduleDeleteDialog()
@@ -66,7 +67,6 @@ class ScheduleManageBottomSheet(
     }
 
     override fun onPosBtnClick() {
-        // TO DO 서버 데이터 삭제 요청
         onScheduleDeleteClickListener()
         dismiss()
     }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/customview/ScheduleReviewManageBottomSheet.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/customview/ScheduleReviewManageBottomSheet.kt
@@ -12,7 +12,9 @@ import kr.tekit.lion.daongil.presentation.schedulereview.ModifyScheduleReviewAct
 
 class ScheduleReviewManageBottomSheet(
     private val reviewId: Long,
-    private val onReviewDeleteClickListener: () -> Unit) :
+    private val onReviewDeleteClickListener: () -> Unit,
+    private val onReviewEditClickListener: () -> Unit,
+) :
     BottomSheetDialogFragment(R.layout.bottom_sheet_schedule_review_manage),
     ConfirmDialogInterface {
 
@@ -27,10 +29,7 @@ class ScheduleReviewManageBottomSheet(
     private fun initView(binding: BottomSheetScheduleReviewManageBinding) {
         binding.apply {
             textViewScheduleReviewManageEdit.setOnClickListener {
-                // 리뷰 수정 화면으로 이동
-                val intent = Intent(requireActivity(), ModifyScheduleReviewActivity::class.java)
-                intent.putExtra("planId", reviewId)
-                startActivity(intent)
+                onReviewEditClickListener()
             }
 
             textViewScheduleReviewManageDelete.setOnClickListener {

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/vm/ScheduleDetailViewModel.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/vm/ScheduleDetailViewModel.kt
@@ -11,6 +11,7 @@ import kr.tekit.lion.daongil.domain.model.ScheduleDetail
 import kr.tekit.lion.daongil.domain.repository.AuthRepository
 import kr.tekit.lion.daongil.domain.usecase.base.onSuccess
 import kr.tekit.lion.daongil.domain.usecase.plan.DeleteMyPlanReviewUseCase
+import kr.tekit.lion.daongil.domain.usecase.plan.DeleteMyPlanScheduleUseCase
 import kr.tekit.lion.daongil.domain.usecase.plan.GetScheduleDetailGuestUsecase
 import kr.tekit.lion.daongil.domain.usecase.plan.GetScheduleDetailUseCase
 import kr.tekit.lion.daongil.domain.usecase.plan.UpdateMyPlanPublicUseCase
@@ -22,6 +23,7 @@ class ScheduleDetailViewModel(
     private val getScheduleDetailGuestUsecase: GetScheduleDetailGuestUsecase,
     private val deleteMyPlanReviewUseCase: DeleteMyPlanReviewUseCase,
     private val updateMyPlanPublicUseCase: UpdateMyPlanPublicUseCase,
+    private val deleteMyPlanScheduleUseCase: DeleteMyPlanScheduleUseCase,
 ) : ViewModel() {
 
     private val _scheduleDetail = MutableLiveData<ScheduleDetail>()
@@ -67,6 +69,13 @@ class ScheduleDetailViewModel(
                 _scheduleDetail.value = _scheduleDetail.value?.copy(
                     isPublic = it.isPublic
                 )
+            }
+        }
+
+    fun deleteMyPlanSchedule(planId: Long) =
+        viewModelScope.launch {
+            deleteMyPlanScheduleUseCase.invoke(planId).onSuccess {
+
             }
         }
 

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/vm/ScheduleDetailViewModel.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/vm/ScheduleDetailViewModel.kt
@@ -1,6 +1,5 @@
 package kr.tekit.lion.daongil.presentation.schedule.vm
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -14,6 +13,7 @@ import kr.tekit.lion.daongil.domain.usecase.base.onSuccess
 import kr.tekit.lion.daongil.domain.usecase.plan.DeleteMyPlanReviewUseCase
 import kr.tekit.lion.daongil.domain.usecase.plan.GetScheduleDetailGuestUsecase
 import kr.tekit.lion.daongil.domain.usecase.plan.GetScheduleDetailUseCase
+import kr.tekit.lion.daongil.domain.usecase.plan.UpdateMyPlanPublicUseCase
 import kr.tekit.lion.daongil.presentation.login.LogInState
 
 class ScheduleDetailViewModel(
@@ -21,6 +21,7 @@ class ScheduleDetailViewModel(
     private val authRepository: AuthRepository,
     private val getScheduleDetailGuestUsecase: GetScheduleDetailGuestUsecase,
     private val deleteMyPlanReviewUseCase: DeleteMyPlanReviewUseCase,
+    private val updateMyPlanPublicUseCase: UpdateMyPlanPublicUseCase,
 ) : ViewModel() {
 
     private val _scheduleDetail = MutableLiveData<ScheduleDetail>()
@@ -56,6 +57,15 @@ class ScheduleDetailViewModel(
                 grade = it.grade,
                 reviewImages = it.imageList,
                 hasReview = it.hasReview
+                )
+            }
+        }
+
+    fun updateMyPlanPublic(planId: Long) =
+        viewModelScope.launch {
+            updateMyPlanPublicUseCase.invoke(planId).onSuccess {
+                _scheduleDetail.value = _scheduleDetail.value?.copy(
+                    isPublic = it.isPublic
                 )
             }
         }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/vm/ScheduleDetailViewModelFactory.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/vm/ScheduleDetailViewModelFactory.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import kr.tekit.lion.daongil.domain.repository.AuthRepository
 import kr.tekit.lion.daongil.domain.repository.PlanRepository
 import kr.tekit.lion.daongil.domain.usecase.plan.DeleteMyPlanReviewUseCase
+import kr.tekit.lion.daongil.domain.usecase.plan.DeleteMyPlanScheduleUseCase
 import kr.tekit.lion.daongil.domain.usecase.plan.GetScheduleDetailGuestUsecase
 import kr.tekit.lion.daongil.domain.usecase.plan.GetScheduleDetailUseCase
 import kr.tekit.lion.daongil.domain.usecase.plan.UpdateMyPlanPublicUseCase
@@ -31,6 +32,10 @@ class ScheduleDetailViewModelFactory(context: Context): ViewModelProvider.Factor
         PlanRepository.create()
     )
 
+    private val deleteMyPlanScheduleUseCase = DeleteMyPlanScheduleUseCase(
+        PlanRepository.create()
+    )
+
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(ScheduleDetailViewModel::class.java)) {
             return ScheduleDetailViewModel(
@@ -38,7 +43,8 @@ class ScheduleDetailViewModelFactory(context: Context): ViewModelProvider.Factor
                 authRepository,
                 getScheduleDetailGuestUsecase,
                 deleteMyPlanReviewUseCase,
-                updateMyPlanPublicUseCase
+                updateMyPlanPublicUseCase,
+                deleteMyPlanScheduleUseCase
             ) as T
         }
         throw IllegalArgumentException("unknown ViewModel class")

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/vm/ScheduleDetailViewModelFactory.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/vm/ScheduleDetailViewModelFactory.kt
@@ -8,6 +8,7 @@ import kr.tekit.lion.daongil.domain.repository.PlanRepository
 import kr.tekit.lion.daongil.domain.usecase.plan.DeleteMyPlanReviewUseCase
 import kr.tekit.lion.daongil.domain.usecase.plan.GetScheduleDetailGuestUsecase
 import kr.tekit.lion.daongil.domain.usecase.plan.GetScheduleDetailUseCase
+import kr.tekit.lion.daongil.domain.usecase.plan.UpdateMyPlanPublicUseCase
 import java.lang.IllegalArgumentException
 
 class ScheduleDetailViewModelFactory(context: Context): ViewModelProvider.Factory {
@@ -25,9 +26,20 @@ class ScheduleDetailViewModelFactory(context: Context): ViewModelProvider.Factor
     private val deleteMyPlanReviewUseCase = DeleteMyPlanReviewUseCase(
         PlanRepository.create()
     )
+
+    private val updateMyPlanPublicUseCase = UpdateMyPlanPublicUseCase(
+        PlanRepository.create()
+    )
+
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
-        if (modelClass.isAssignableFrom(ScheduleDetailViewModel::class.java)){
-            return ScheduleDetailViewModel(getScheduleDetailUseCase, authRepository, getScheduleDetailGuestUsecase, deleteMyPlanReviewUseCase) as T
+        if (modelClass.isAssignableFrom(ScheduleDetailViewModel::class.java)) {
+            return ScheduleDetailViewModel(
+                getScheduleDetailUseCase,
+                authRepository,
+                getScheduleDetailGuestUsecase,
+                deleteMyPlanReviewUseCase,
+                updateMyPlanPublicUseCase
+            ) as T
         }
         throw IllegalArgumentException("unknown ViewModel class")
     }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedulereview/WriteScheduleReviewActivity.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedulereview/WriteScheduleReviewActivity.kt
@@ -23,6 +23,8 @@ import kr.tekit.lion.daongil.domain.model.NewScheduleReview
 import kr.tekit.lion.daongil.presentation.ext.toAbsolutePath
 import kr.tekit.lion.daongil.presentation.main.dialog.ConfirmDialog
 import kr.tekit.lion.daongil.presentation.main.dialog.ConfirmDialogInterface
+import kr.tekit.lion.daongil.presentation.schedule.ResultCode
+import kr.tekit.lion.daongil.presentation.schedule.ResultCode.RESULT_REVIEW_WRITE
 import kr.tekit.lion.daongil.presentation.schedulereview.adapter.WriteReviewImageAdapter
 import kr.tekit.lion.daongil.presentation.schedulereview.vm.WriteScheduleReviewViewModel
 import kr.tekit.lion.daongil.presentation.schedulereview.vm.WriteScheduleReviewViewModelFactory
@@ -151,7 +153,7 @@ class WriteScheduleReviewActivity : AppCompatActivity() ,ConfirmDialogInterface 
 
                     viewModel.submitScheduleReview(planId, reviewDetail) { _, requestFlag ->
                         if (requestFlag) {
-                            setResult(Activity.RESULT_OK)
+                            setResult(RESULT_REVIEW_WRITE)
                             finish()
                         }
                     }

--- a/DaOnGil/app/src/main/res/values/strings.xml
+++ b/DaOnGil/app/src/main/res/values/strings.xml
@@ -111,6 +111,7 @@
     <string name="text_schedule_changed_to_private">여행 일정이 비공개되었습니다.</string>
     <string name="text_schedule_changed_to_public">여행 일정이 공개되었습니다.</string>
     <string name="text_schedule_review_deleted">여행 일정 후기가 삭제되었습니다.</string>
+    <string name="text_schedule_deleted">여행 일정 후기가 삭제되었습니다.</string>
     <string name="text_report_reason">신고 사유</string>
     <string name="text_report_commercial_promotion">영리목적/홍보성</string>
     <string name="text_report_copyright_infringement">저작권 침해</string>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #251 

## 📝작업 내용

- 본인 일정 상세보기 페이지에서 일정 관련 필요한 기능 구현했습니다.
    -  일정 상세보기에서 일정 공개, 비공개 하기
    - 일정 상세보기에서 일정 삭제하기

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)

https://github.com/user-attachments/assets/c9379f46-a0c5-49b2-9ec7-b446e5ecb9fe


## 💬리뷰 요구사항(선택)

- 특별하게 봐주실 건 없는 것 같지만... 그래도 리뷰 잘 부탁드립니다아...!!
