### PR TITLE
[#248] 여행일정 수정 UI, API 연결

### DIFF
--- a/DaOnGil/app/src/main/AndroidManifest.xml
+++ b/DaOnGil/app/src/main/AndroidManifest.xml
@@ -24,6 +24,9 @@
             android:name=".presentation.schedulereview.ModifyScheduleReviewActivity"
             android:exported="false" />
         <activity
+            android:name=".presentation.scheduleform.ModifyScheduleFormActivity"
+            android:exported="false" />
+        <activity
             android:name=".presentation.report.ReportActivity"
             android:exported="false" />
         <activity

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/datasource/PlanDataSource.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/datasource/PlanDataSource.kt
@@ -22,6 +22,11 @@ class PlanDataSource(
     suspend fun addNewPlan(request: RequestBody){
         planService.addNewPlan(request)
     }
+
+    suspend fun modifySchedule(planId: Long, request: RequestBody){
+        planService.modifySchedule(planId, request)
+    }
+
     suspend fun getPlaceSearchResult(word: String, page: Int, size: Int) : PlaceSearchResultsResponse {
         return planService.getPlaceSearchResults(word, page, size)
     }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/plan/scheduleDetail/DailyPlaceInfo.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/dto/remote/response/plan/scheduleDetail/DailyPlaceInfo.kt
@@ -4,6 +4,7 @@ import kr.tekit.lion.daongil.domain.model.SchedulePlace
 
 data class DailyPlaceInfo(
     val category: String,
+    val imageUrl: String?,
     val disabilityCategoryList: List<Int>,
     val name: String,
     val placeId: Long
@@ -13,6 +14,7 @@ data class DailyPlaceInfo(
             placeId = placeId,
             name = name,
             category = category,
+            imageUrl = imageUrl ?: "",
             disability = disabilityCategoryList
         )
     }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/service/PlanService.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/network/service/PlanService.kt
@@ -13,6 +13,7 @@ import okhttp3.RequestBody
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Multipart
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Part
 import retrofit2.http.Path
@@ -42,6 +43,13 @@ interface PlanService {
     suspend fun addNewPlan(
         @Body newPlan: RequestBody,
         @Tag authType: AuthType = AuthType.ACCESS_TOKEN
+    )
+
+    // 일정 수정
+    @PATCH("plan/{planId}")
+    suspend fun modifySchedule(
+        @Path("planId") planId: Long,
+        @Body newPlan: RequestBody
     )
 
     // 내 일정 정보

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/repository/PlanRepositoryImpl.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/data/repository/PlanRepositoryImpl.kt
@@ -27,6 +27,10 @@ class PlanRepositoryImpl(
         return planDataSource.addNewPlan(request.toRequestBody())
     }
 
+    override suspend fun modifySchedule(planId: Long, request: NewPlan) {
+        return planDataSource.modifySchedule(planId, request.toRequestBody())
+    }
+
     override suspend fun getPlaceSearchResult(word: String, page: Int, size: Int
     ): PlaceSearchResult {
         return planDataSource.getPlaceSearchResult(word, page, size).toDomainModel()

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/SchedulePlace.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/model/SchedulePlace.kt
@@ -4,6 +4,7 @@ data class SchedulePlace(
     val placeId: Long,
     val name: String,
     val category: String,
+    val imageUrl: String,
     // 무장애 유형 정보
     // 1 (지체 장애), 2 (시각 장애), 3 (청각 장애), 4 (유아 동반), 5 (고령자)
     val disability: List<Int>,

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/repository/PlanRepository.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/repository/PlanRepository.kt
@@ -20,6 +20,8 @@ interface PlanRepository {
 
     suspend fun addNewPlan(request: NewPlan)
 
+    suspend fun modifySchedule(planId: Long, request: NewPlan)
+
     // 구현해야 할 메서드
     suspend fun getPlaceSearchResult(word: String, page: Int, size: Int) : PlaceSearchResult
 

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/place/GetPlaceSearchResultUseCase.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/place/GetPlaceSearchResultUseCase.kt
@@ -11,9 +11,14 @@ class GetPlaceSearchResultUseCase(
 ) : BaseUseCase() {
     // Result : usecase.base에 정의된 클래스
     // execute : BaseUseCase 에서 구현된 메서드
-    suspend operator fun invoke(word: String, page: Int, size: Int): Result<PlaceSearchResult> =
+
+    companion object{
+        private const val PAGE_SIZE = 20
+    }
+
+    suspend operator fun invoke(word: String, page: Int): Result<PlaceSearchResult> =
         execute {
             // 리포지토리를 통해 북마크된 장소 목록을 가져온다. (람다함수)
-            planRepository.getPlaceSearchResult(word, page, size)
+            planRepository.getPlaceSearchResult(word, page, PAGE_SIZE)
         }
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/plan/ModifyScheduleUseCase.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/domain/usecase/plan/ModifyScheduleUseCase.kt
@@ -1,0 +1,15 @@
+package kr.tekit.lion.daongil.domain.usecase.plan
+
+import kr.tekit.lion.daongil.domain.model.NewPlan
+import kr.tekit.lion.daongil.domain.repository.PlanRepository
+import kr.tekit.lion.daongil.domain.usecase.base.BaseUseCase
+import kr.tekit.lion.daongil.domain.usecase.base.Result
+
+class ModifyScheduleUseCase (
+    private val planRepository: PlanRepository
+) : BaseUseCase() {
+
+    suspend operator fun invoke(planId: Long, request: NewPlan): Result<Unit> = execute {
+        planRepository.modifySchedule(planId, request)
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/ext/SnackbarExt.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/ext/SnackbarExt.kt
@@ -1,0 +1,12 @@
+package kr.tekit.lion.daongil.presentation.ext
+
+import android.view.View
+import androidx.core.content.ContextCompat
+import com.google.android.material.snackbar.Snackbar
+import kr.tekit.lion.daongil.R
+
+fun View.showSnackbar(message: String, duration: Int = Snackbar.LENGTH_SHORT){
+    Snackbar.make(this, message, duration)
+        .setBackgroundTint(ContextCompat.getColor(this.context, R.color.text_secondary))
+        .show()
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/ModifyScheduleFormActivity.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/ModifyScheduleFormActivity.kt
@@ -2,10 +2,17 @@ package kr.tekit.lion.daongil.presentation.scheduleform
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import kr.tekit.lion.daongil.databinding.ActivityModifyScheduleFormBinding
 
 class ModifyScheduleFormActivity : AppCompatActivity() {
+    private val binding: ActivityModifyScheduleFormBinding by lazy {
+        ActivityModifyScheduleFormBinding.inflate(layoutInflater)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        setContentView(binding.root)
 
     }
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/ModifyScheduleFormActivity.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/ModifyScheduleFormActivity.kt
@@ -1,0 +1,11 @@
+package kr.tekit.lion.daongil.presentation.scheduleform
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+class ModifyScheduleFormActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/FormSearchFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/FormSearchFragment.kt
@@ -99,7 +99,7 @@ class FormSearchFragment : Fragment(R.layout.fragment_form_search) {
             addOnScrollEndListener{
                 with(scheduleFormViewModel){
                     if(!isLastPage()){
-                        fetchNextPlaceResults(20)
+                        fetchNextPlaceResults()
                     }
                 }
             }
@@ -152,7 +152,7 @@ class FormSearchFragment : Fragment(R.layout.fragment_form_search) {
                     }else{
                         binding.recyclerViewFSResult.visibility = View.VISIBLE
                         binding.textViewFSResultEmpty.visibility = View.GONE
-                        scheduleFormViewModel.getPlaceSearchResult(word, 0, 20)
+                        scheduleFormViewModel.getPlaceSearchResult(word, 0)
                     }
                 }
                 false

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyNamePeriodFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyNamePeriodFragment.kt
@@ -22,15 +22,24 @@ class ModifyNamePeriodFragment : Fragment(R.layout.fragment_modify_name_period) 
 
         val binding = FragmentModifyNamePeriodBinding.bind(view)
 
+        initToolbar(binding)
         initScheduleData(binding)
         setPeriod(binding)
         initButtonNextStep(binding)
     }
 
-    private fun initScheduleData(binding: FragmentModifyNamePeriodBinding){
-        val planId = requireActivity().intent.getLongExtra("planId", -1)
-        viewModel.initScheduleDetailInfo(planId)
+    private fun initToolbar(binding: FragmentModifyNamePeriodBinding){
+        binding.toolbarModifyNP.setNavigationOnClickListener {
+            requireActivity().finish()
+        }
+    }
 
+    private fun initScheduleData(binding: FragmentModifyNamePeriodBinding){
+        binding.textInputModifyName.showSnackbar("startdate= ${viewModel.startDate.value}")
+        if(!viewModel.hasStartDate()){
+            val planId = requireActivity().intent.getLongExtra("planId", -1)
+            viewModel.initScheduleDetailInfo(planId)
+        }
         initScheduleName(binding)
         initSchedulePeriod(binding)
     }
@@ -69,6 +78,8 @@ class ModifyNamePeriodFragment : Fragment(R.layout.fragment_modify_name_period) 
                 val isNameAndPeriodValidate = validateScheduleNameAndPeriod(this)
 
                 if(isNameAndPeriodValidate){
+                    viewModel.setTitle(editTextModifyName.text.toString())
+
                     val navController = findNavController()
                     val action = ModifyNamePeriodFragmentDirections.actionModifyNamePeriodFragmentToModifyScheduleDetailsFragment()
                     navController.navigate(action)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyNamePeriodFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyNamePeriodFragment.kt
@@ -1,9 +1,106 @@
 package kr.tekit.lion.daongil.presentation.scheduleform.fragment
 
+import android.os.Bundle
+import android.util.Log
+import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.navigation.fragment.findNavController
+import com.google.android.material.datepicker.MaterialDatePicker
 import kr.tekit.lion.daongil.R
+import kr.tekit.lion.daongil.databinding.FragmentModifyNamePeriodBinding
+import kr.tekit.lion.daongil.presentation.ext.showSnackbar
+import kr.tekit.lion.daongil.presentation.scheduleform.vm.ModifyScheduleFormViewModel
+import kr.tekit.lion.daongil.presentation.scheduleform.vm.ModifyScheduleFormViewModelFactory
+import java.util.*
 
 
 class ModifyNamePeriodFragment : Fragment(R.layout.fragment_modify_name_period) {
+    private val viewModel: ModifyScheduleFormViewModel by activityViewModels { ModifyScheduleFormViewModelFactory() }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val binding = FragmentModifyNamePeriodBinding.bind(view)
+
+        initScheduleData(binding)
+        setPeriod(binding)
+        initButtonNextStep(binding)
+    }
+
+    private fun initScheduleData(binding: FragmentModifyNamePeriodBinding){
+        val planId = requireActivity().intent.getLongExtra("planId", -1)
+        viewModel.initScheduleDetailInfo(planId)
+
+        initScheduleName(binding)
+        initSchedulePeriod(binding)
+    }
+
+    private fun initScheduleName(binding: FragmentModifyNamePeriodBinding){
+        viewModel.title.observe(viewLifecycleOwner){
+            binding.editTextModifyName.setText(it)
+        }
+    }
+
+    private fun initSchedulePeriod(binding: FragmentModifyNamePeriodBinding){
+        viewModel.endDate.observe(viewLifecycleOwner){
+            val pickedDates = viewModel.formatPickedDates()
+            binding.buttonModifyPeriod.text = pickedDates
+        }
+    }
+
+    private fun setPeriod(binding: FragmentModifyNamePeriodBinding) {
+        binding.buttonModifyPeriod.setOnClickListener {
+            val dateRangePicker = MaterialDatePicker.Builder.dateRangePicker()
+                .setTheme(R.style.DateRangePickerTheme)
+                .setTitleText("조회기간을 설정해주세요")
+                .build()
+
+            dateRangePicker.show(requireActivity().supportFragmentManager, "ModifyScheduleFormSetPeriod")
+            dateRangePicker.addOnPositiveButtonClickListener {
+                viewModel.setStartDate(Date(it.first))
+                viewModel.setEndDate(Date(it.second))
+            }
+        }
+    }
+
+    private fun initButtonNextStep(binding: FragmentModifyNamePeriodBinding){
+        binding.apply {
+            buttonModifyNPNextStep.setOnClickListener { view ->
+                val isNameAndPeriodValidate = validateScheduleNameAndPeriod(this)
+
+                if(isNameAndPeriodValidate){
+                    Log.d("test1234", "sdfsdfsdfsdf")
+                    val navController = findNavController()
+                    val action = ModifyNamePeriodFragmentDirections.actionModifyNamePeriodFragmentToModifyScheduleDetailsFragment()
+                    navController.navigate(action)
+                }
+            }
+        }
+    }
+
+    private fun validateScheduleNameAndPeriod(binding: FragmentModifyNamePeriodBinding): Boolean {
+        with(binding) {
+            editTextModifyName.apply {
+                val tempName = this.text.toString()
+
+                if (tempName.isEmpty()) {
+                    textInputModifyName.error = "제목은 1글자 이상 입력해주세요"
+                    return false
+                }
+            }
+
+            val hasStartDate = viewModel.hasStartDate()
+
+            if (!hasStartDate) {
+                buttonModifyPeriod.showSnackbar("여행 기간을 설정해주세요")
+                return false
+            } else {
+                // 여행 기간 재설정했다면, 여행지 목록도 재설정 해준다.
+                viewModel.isPeriodReset()
+            }
+        }
+
+        return true
+    }
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyNamePeriodFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyNamePeriodFragment.kt
@@ -1,8 +1,9 @@
 package kr.tekit.lion.daongil.presentation.scheduleform.fragment
 
 import androidx.fragment.app.Fragment
+import kr.tekit.lion.daongil.R
 
 
-class ModifyNamePeriodFragment : Fragment() {
+class ModifyNamePeriodFragment : Fragment(R.layout.fragment_modify_name_period) {
 
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyNamePeriodFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyNamePeriodFragment.kt
@@ -1,0 +1,8 @@
+package kr.tekit.lion.daongil.presentation.scheduleform.fragment
+
+import androidx.fragment.app.Fragment
+
+
+class ModifyNamePeriodFragment : Fragment() {
+
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyNamePeriodFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyNamePeriodFragment.kt
@@ -1,7 +1,6 @@
 package kr.tekit.lion.daongil.presentation.scheduleform.fragment
 
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -70,7 +69,6 @@ class ModifyNamePeriodFragment : Fragment(R.layout.fragment_modify_name_period) 
                 val isNameAndPeriodValidate = validateScheduleNameAndPeriod(this)
 
                 if(isNameAndPeriodValidate){
-                    Log.d("test1234", "sdfsdfsdfsdf")
                     val navController = findNavController()
                     val action = ModifyNamePeriodFragmentDirections.actionModifyNamePeriodFragmentToModifyScheduleDetailsFragment()
                     navController.navigate(action)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyNamePeriodFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyNamePeriodFragment.kt
@@ -35,7 +35,6 @@ class ModifyNamePeriodFragment : Fragment(R.layout.fragment_modify_name_period) 
     }
 
     private fun initScheduleData(binding: FragmentModifyNamePeriodBinding){
-        binding.textInputModifyName.showSnackbar("startdate= ${viewModel.startDate.value}")
         if(!viewModel.hasStartDate()){
             val planId = requireActivity().intent.getLongExtra("planId", -1)
             viewModel.initScheduleDetailInfo(planId)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyScheduleConfirmFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyScheduleConfirmFragment.kt
@@ -1,8 +1,76 @@
 package kr.tekit.lion.daongil.presentation.scheduleform.fragment
 
+import android.app.Activity
+import android.os.Bundle
+import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.navigation.fragment.findNavController
 import kr.tekit.lion.daongil.R
+import kr.tekit.lion.daongil.databinding.FragmentModifyScheduleConfirmBinding
+import kr.tekit.lion.daongil.domain.model.DailySchedule
+import kr.tekit.lion.daongil.presentation.ext.showSnackbar
+import kr.tekit.lion.daongil.presentation.scheduleform.adapter.FormConfirmScheduleAdapter
+import kr.tekit.lion.daongil.presentation.scheduleform.vm.ModifyScheduleFormViewModel
+import kr.tekit.lion.daongil.presentation.scheduleform.vm.ModifyScheduleFormViewModelFactory
 
 class ModifyScheduleConfirmFragment : Fragment(R.layout.fragment_modify_schedule_confirm) {
 
+    private val viewModel: ModifyScheduleFormViewModel by activityViewModels {
+        ModifyScheduleFormViewModelFactory()
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val binding = FragmentModifyScheduleConfirmBinding.bind(view)
+
+        val planId = requireActivity().intent.getLongExtra("planId", -1)
+
+        initToolbar(binding)
+        initView(binding)
+        initButtonSubmit(planId, binding)
+    }
+
+    private fun initToolbar(binding: FragmentModifyScheduleConfirmBinding) {
+        binding.toolbarModifyConfirm.setNavigationOnClickListener {
+            findNavController().popBackStack()
+        }
+    }
+
+    private fun initView(binding: FragmentModifyScheduleConfirmBinding){
+        val title = viewModel.getScheduleTitle()
+        val period = viewModel.getSchedulePeriod()
+        binding.apply {
+            textViewModifyConfirmTitle.text = getString(R.string.text_selected_title, title)
+            textViewModifyConfirmDate.text = getString(R.string.text_selected_period, period)
+        }
+
+        viewModel.schedule.observe(viewLifecycleOwner){
+            if(it != null) settingConfirmScheduleAdapter(binding, it)
+        }
+    }
+
+    private fun settingConfirmScheduleAdapter(
+        binding: FragmentModifyScheduleConfirmBinding,
+        dailyScheduleList: List<DailySchedule>
+    ){
+        binding.recyclerViewModifyConfirm.adapter = FormConfirmScheduleAdapter(dailyScheduleList)
+    }
+
+    private fun initButtonSubmit(planId: Long, binding: FragmentModifyScheduleConfirmBinding){
+        binding.buttonModifyConfirmSubmit.setOnClickListener { view ->
+            viewModel.submitRevisedSchedule(planId){ _, flag ->
+                if(flag){
+                    view.showSnackbar("여행 일정이 수정되었습니다")
+
+                    // TO DO 예인님이 수정할 예정
+                    requireActivity().setResult(Activity.RESULT_OK)
+                    requireActivity().finish()
+                }else{
+                    view.showSnackbar("다시 시도해 주세요")
+                }
+            }
+        }
+    }
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyScheduleConfirmFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyScheduleConfirmFragment.kt
@@ -1,0 +1,6 @@
+package kr.tekit.lion.daongil.presentation.scheduleform.fragment
+
+import androidx.fragment.app.Fragment
+class ModifyScheduleConfirmFragment : Fragment() {
+
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyScheduleConfirmFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyScheduleConfirmFragment.kt
@@ -1,6 +1,8 @@
 package kr.tekit.lion.daongil.presentation.scheduleform.fragment
 
 import androidx.fragment.app.Fragment
-class ModifyScheduleConfirmFragment : Fragment() {
+import kr.tekit.lion.daongil.R
+
+class ModifyScheduleConfirmFragment : Fragment(R.layout.fragment_modify_schedule_confirm) {
 
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyScheduleDetailsFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyScheduleDetailsFragment.kt
@@ -1,8 +1,9 @@
 package kr.tekit.lion.daongil.presentation.scheduleform.fragment
 
 import androidx.fragment.app.Fragment
+import kr.tekit.lion.daongil.R
 
 
-class ModifyScheduleDetailsFragment : Fragment() {
+class ModifyScheduleDetailsFragment : Fragment(R.layout.fragment_modify_schedule_details) {
 
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyScheduleDetailsFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyScheduleDetailsFragment.kt
@@ -1,0 +1,8 @@
+package kr.tekit.lion.daongil.presentation.scheduleform.fragment
+
+import androidx.fragment.app.Fragment
+
+
+class ModifyScheduleDetailsFragment : Fragment() {
+
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyScheduleDetailsFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifyScheduleDetailsFragment.kt
@@ -1,9 +1,88 @@
 package kr.tekit.lion.daongil.presentation.scheduleform.fragment
 
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.navigation.fragment.findNavController
 import kr.tekit.lion.daongil.R
+import kr.tekit.lion.daongil.databinding.FragmentModifyScheduleDetailsBinding
+import kr.tekit.lion.daongil.domain.model.DailySchedule
+import kr.tekit.lion.daongil.presentation.home.DetailActivity
+import kr.tekit.lion.daongil.presentation.scheduleform.adapter.FormScheduleAdapter
+import kr.tekit.lion.daongil.presentation.scheduleform.vm.ModifyScheduleFormViewModel
+import kr.tekit.lion.daongil.presentation.scheduleform.vm.ModifyScheduleFormViewModelFactory
 
 
 class ModifyScheduleDetailsFragment : Fragment(R.layout.fragment_modify_schedule_details) {
+    private val viewModel: ModifyScheduleFormViewModel by activityViewModels {
+        ModifyScheduleFormViewModelFactory()
+    }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val binding = FragmentModifyScheduleDetailsBinding.bind(view)
+
+        initToolbar(binding)
+        initView(binding)
+        initButtonNextStep(binding)
+    }
+
+    private fun initToolbar(binding: FragmentModifyScheduleDetailsBinding){
+        binding.toolbarModifyDetails.setNavigationOnClickListener {
+            findNavController().popBackStack()
+        }
+    }
+
+    private fun initView(binding: FragmentModifyScheduleDetailsBinding){
+        with(binding){
+            val title = viewModel.getScheduleTitle()
+            textViewModifyDetailTitle.text = getString(R.string.text_selected_title, title)
+            val period = viewModel.getSchedulePeriod()
+            textViewModifyDetailDate.text = getString(R.string.text_selected_period, period)
+        }
+
+        viewModel.schedule.observe(viewLifecycleOwner){
+            it?.let {
+                settingScheduleFormAdapter(binding, it)
+            }
+        }
+    }
+
+    private fun settingScheduleFormAdapter(
+        binding: FragmentModifyScheduleDetailsBinding,
+        dailyScheduleList: List<DailySchedule>
+    ){
+        binding.recyclerViewModifyDetail.adapter = FormScheduleAdapter(
+            dailyScheduleList,
+            onAddButtonClickListener = { schedulePosition ->
+                val action = ModifyScheduleDetailsFragmentDirections.actionModifyScheduleDetailsFragmentToModifySearchFragment(
+                    schedulePosition
+                )
+                findNavController().navigate(action)
+            },
+            onItemClickListener = { schedulePosition, placePosition ->
+                val placeId = dailyScheduleList[schedulePosition].dailyPlaces[placePosition].placeId
+                showPlaceDetail(placeId)
+            },
+            onRemoveButtonClickListener = { schedulePosition, placePosition ->
+                viewModel.removePlace(schedulePosition, placePosition)
+            }
+        )
+    }
+
+    private fun initButtonNextStep(binding: FragmentModifyScheduleDetailsBinding){
+        binding.buttonModifyDetailNextStep.setOnClickListener { view ->
+            val action = ModifyScheduleDetailsFragmentDirections.actionModifyScheduleDetailsFragmentToModifyScheduleConfirmFragment()
+            findNavController().navigate(action)
+        }
+    }
+
+    private fun showPlaceDetail(placeId: Long){
+        val intent = Intent(requireActivity(), DetailActivity::class.java)
+        intent.putExtra("detailPlaceId", placeId)
+        startActivity(intent)
+    }
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifySearchFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifySearchFragment.kt
@@ -1,0 +1,8 @@
+package kr.tekit.lion.daongil.presentation.scheduleform.fragment
+
+import androidx.fragment.app.Fragment
+import kr.tekit.lion.daongil.R
+
+
+class ModifySearchFragment : Fragment(R.layout.fragment_modify_search) {
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifySearchFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ModifySearchFragment.kt
@@ -1,8 +1,153 @@
 package kr.tekit.lion.daongil.presentation.scheduleform.fragment
 
+import android.content.Intent
+import android.os.Bundle
+import android.view.KeyEvent
+import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import com.google.android.flexbox.AlignItems
+import com.google.android.flexbox.FlexDirection
+import com.google.android.flexbox.FlexWrap
+import com.google.android.flexbox.FlexboxLayoutManager
+import com.google.android.flexbox.JustifyContent
 import kr.tekit.lion.daongil.R
+import kr.tekit.lion.daongil.databinding.FragmentModifySearchBinding
+import kr.tekit.lion.daongil.presentation.ext.addOnScrollEndListener
+import kr.tekit.lion.daongil.presentation.ext.showSnackbar
+import kr.tekit.lion.daongil.presentation.home.DetailActivity
+import kr.tekit.lion.daongil.presentation.scheduleform.adapter.FormBookmarkedPlacesAdapter
+import kr.tekit.lion.daongil.presentation.scheduleform.adapter.FormSearchResultAdapter
+import kr.tekit.lion.daongil.presentation.scheduleform.vm.ModifyScheduleFormViewModel
+import kr.tekit.lion.daongil.presentation.scheduleform.vm.ModifyScheduleFormViewModelFactory
 
 
 class ModifySearchFragment : Fragment(R.layout.fragment_modify_search) {
+    private val args: ModifySearchFragmentArgs by navArgs()
+    private val viewModel: ModifyScheduleFormViewModel by activityViewModels {
+        ModifyScheduleFormViewModelFactory()
+    }
+
+    private val searchResultAdapter by lazy {
+        FormSearchResultAdapter(
+            onPlaceSelectedListener = { selectedPlacePosition ->
+                addNewPlace(args.schedulePosition, selectedPlacePosition, false, requireView())
+            },
+            onItemClickListener = { selectedPlacePosition ->
+                val placeId = viewModel.getPlaceId(selectedPlacePosition)
+                if(placeId != -1L){
+                    showPlaceDetail(placeId)
+                }
+            }
+        )
+    }
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val schedulePosition = args.schedulePosition
+
+        val binding = FragmentModifySearchBinding.bind(view)
+
+        initToolbar(binding)
+        settingBookmarkRV(binding, schedulePosition)
+        settingSearchResultRV(binding)
+        settingPlaceSearchView(binding)
+    }
+
+    private fun initToolbar(binding: FragmentModifySearchBinding){
+        binding.toolbarModifySearch.setNavigationOnClickListener {
+            findNavController().popBackStack()
+        }
+    }
+
+    private fun settingBookmarkRV(binding: FragmentModifySearchBinding, schedulePosition: Int ){
+        val flexboxLayoutManager = FlexboxLayoutManager(requireActivity()).apply {
+            flexDirection = FlexDirection.ROW
+            flexWrap = FlexWrap.WRAP
+            alignItems = AlignItems.FLEX_START
+            justifyContent = JustifyContent.FLEX_START
+        }
+
+        viewModel.bookmarkedPlaces.observe(viewLifecycleOwner){
+            if(it.isNotEmpty()){
+                binding.recyclerViewModifyBookmark.apply {
+                    layoutManager = flexboxLayoutManager
+                    adapter = FormBookmarkedPlacesAdapter(it){ selectedPlacePosition ->
+                        addNewPlace(schedulePosition, selectedPlacePosition, true, this)
+                    }
+                }
+            }else{
+                // 북마크한 여행지가 없다면
+                binding.apply {
+                    recyclerViewModifyBookmark.visibility = View.INVISIBLE
+                    textViewModifyBookmarkEmpty.visibility = View.VISIBLE
+                }
+            }
+        }
+    }
+
+    private fun addNewPlace(schedulePosition: Int, selectedPlacePosition: Int, isBookmarkedPlace: Boolean, view: View) {
+        val isDuplicate = viewModel.isPlaceAlreadyAdded(
+            schedulePosition,
+            selectedPlacePosition,
+            isBookmarkedPlace
+        )
+        if (isDuplicate) {
+            view.showSnackbar("이 여행지는 이미 일정에 추가되어 있습니다")
+        } else {
+            viewModel.getSearchedPlaceDetailInfo(
+                schedulePosition,
+                selectedPlacePosition,
+                isBookmarkedPlace
+            )
+            findNavController().popBackStack()
+        }
+    }
+
+    private fun settingSearchResultRV(binding: FragmentModifySearchBinding){
+        binding.recyclerViewModifySearchResult.apply {
+            adapter = searchResultAdapter
+            addOnScrollEndListener{
+                with(viewModel){
+                    if(!isLastPage()){
+                        fetchNextPlaceResults()
+                    }
+                }
+            }
+        }
+
+        viewModel.searchResultsWithNum.observe(viewLifecycleOwner) {
+            // ListAdapter 사용 시, submitList 메서드를 호출하여 데이터를 전달해준다.
+            searchResultAdapter.submitList(it)
+            if (it.size <= 1) {
+                binding.textViewModifySearchResultEmpty.visibility = View.VISIBLE
+            }
+        }
+    }
+
+    private fun settingPlaceSearchView(binding: FragmentModifySearchBinding){
+        binding.searchViewModifySearchResult.apply {
+            editText.setOnEditorActionListener { textView, actionId, event ->
+                if(event!=null && event.action == KeyEvent.ACTION_DOWN){
+                    val word = editText.text.toString()
+                    if(word.isEmpty()){
+                        this.showSnackbar("검색어를 입력해주세요")
+                    }else{
+                        binding.recyclerViewModifySearchResult.visibility = View.VISIBLE
+                        binding.textViewModifySearchResultEmpty.visibility = View.GONE
+                        viewModel.getPlaceSearchResult(word, 0)
+                    }
+                }
+                false
+            }
+        }
+    }
+
+    private fun showPlaceDetail(placeId: Long){
+        val intent = Intent(requireActivity(), DetailActivity::class.java)
+        intent.putExtra("detailPlaceId", placeId)
+        startActivity(intent)
+    }
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ScheduleConfirmFormFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ScheduleConfirmFormFragment.kt
@@ -3,14 +3,13 @@ package kr.tekit.lion.daongil.presentation.scheduleform.fragment
 import android.app.Activity
 import android.os.Bundle
 import android.view.View
-import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
-import com.google.android.material.snackbar.Snackbar
 import kr.tekit.lion.daongil.R
 import kr.tekit.lion.daongil.databinding.FragmentScheduleConfirmFormBinding
 import kr.tekit.lion.daongil.domain.model.DailySchedule
+import kr.tekit.lion.daongil.presentation.ext.showSnackbar
 import kr.tekit.lion.daongil.presentation.scheduleform.adapter.FormConfirmScheduleAdapter
 import kr.tekit.lion.daongil.presentation.scheduleform.vm.ScheduleFormViewModel
 import kr.tekit.lion.daongil.presentation.scheduleform.vm.ScheduleFormViewModelFactory
@@ -65,15 +64,9 @@ class ScheduleConfirmFormFragment : Fragment(R.layout.fragment_schedule_confirm_
                     requireActivity().setResult(Activity.RESULT_OK)
                     requireActivity().finish()
                 }else{
-                    showSnackBar(view, "다시 시도해주세요")
+                    view.showSnackbar("다시 시도해주세요")
                 }
             }
         }
-    }
-
-    private fun showSnackBar(view: View, message : String ){
-        Snackbar.make(view, message, Snackbar.LENGTH_LONG)
-            .setBackgroundTint(ContextCompat.getColor(requireActivity(), R.color.text_secondary))
-            .show()
     }
 }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/vm/ModifyScheduleFormViewModel.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/vm/ModifyScheduleFormViewModel.kt
@@ -73,6 +73,10 @@ class ModifyScheduleFormViewModel (
         getBookmarkedPlaceList()
     }
 
+    fun setTitle(title: String?){
+        _title.value = title
+    }
+
     fun setStartDate(startDate: Date?){
         _startDate.value = startDate
     }

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/vm/ModifyScheduleFormViewModel.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/vm/ModifyScheduleFormViewModel.kt
@@ -146,7 +146,7 @@ class ModifyScheduleFormViewModel (
                     FormPlace(
                         placeId = schedulePlace.placeId,
                         placeName = schedulePlace.name,
-                        placeImage = "",
+                        placeImage = schedulePlace.imageUrl,
                         placeCategory = schedulePlace.category
 
                     )

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/vm/ModifyScheduleFormViewModel.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/vm/ModifyScheduleFormViewModel.kt
@@ -1,0 +1,203 @@
+package kr.tekit.lion.daongil.presentation.scheduleform.vm
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import kr.tekit.lion.daongil.domain.model.BookmarkedPlace
+import kr.tekit.lion.daongil.domain.model.DailyPlan
+import kr.tekit.lion.daongil.domain.model.DailySchedule
+import kr.tekit.lion.daongil.domain.model.FormPlace
+import kr.tekit.lion.daongil.domain.model.PlaceSearchInfoList
+import kr.tekit.lion.daongil.domain.model.PlaceSearchResult
+import kr.tekit.lion.daongil.domain.model.ScheduleDetail
+import kr.tekit.lion.daongil.domain.usecase.base.onError
+import kr.tekit.lion.daongil.domain.usecase.base.onSuccess
+import kr.tekit.lion.daongil.domain.usecase.place.GetPlaceBookmarkListUseCase
+import kr.tekit.lion.daongil.domain.usecase.place.GetPlaceDetailInfoUseCase
+import kr.tekit.lion.daongil.domain.usecase.place.GetPlaceSearchResultUseCase
+import kr.tekit.lion.daongil.domain.usecase.plan.GetScheduleDetailInfoUseCase
+import java.text.SimpleDateFormat
+import java.util.*
+import java.util.concurrent.TimeUnit
+
+class ModifyScheduleFormViewModel (
+    private val getScheduleDetailInfoUseCase: GetScheduleDetailInfoUseCase,
+    private val getPlaceSearchResultUseCase: GetPlaceSearchResultUseCase,
+    private val getPlaceDetailInfoUseCase: GetPlaceDetailInfoUseCase,
+    private val getPlaceBookmarkListUseCase: GetPlaceBookmarkListUseCase,
+    // + patch schedule use case
+) : ViewModel() {
+
+    // 수정 전 일정 정보
+    private val _originalSchedule = MutableLiveData<ScheduleDetail>()
+
+    // UI에 보여지는 정보 (시작일, 종료일, 여행명, 스케쥴)
+    private val _startDate = MutableLiveData<Date?>()
+    val startDate: LiveData<Date?> get() = _startDate
+
+    private val _endDate = MutableLiveData<Date?>()
+    val endDate: LiveData<Date?> get() = _endDate
+
+    private val _title = MutableLiveData<String?>()
+    val title: LiveData<String?> get() = _title
+
+    private val _schedule = MutableLiveData<List<DailySchedule>?>()
+    val schedule : LiveData<List<DailySchedule>?> get() = _schedule
+
+    // 북마크한 여행지 목록
+    private val _bookmarkedPlaces = MutableLiveData<List<BookmarkedPlace>>()
+    val bookmarkedPlaces: LiveData<List<BookmarkedPlace>> get() = _bookmarkedPlaces
+
+    // 여행지 검색 결과 목록
+    private val _placeSearchResult = MutableLiveData<PlaceSearchResult>()
+
+    private val _keyword = MutableLiveData<String>()
+
+    // 검색 결과 수와 장소 목록을 하나의 List로 관리
+    private val _searchResultsWithNum = MediatorLiveData<List<PlaceSearchInfoList>>().apply {
+        // _placeSearchResult: 이 값이 변경될 때마다 값 update
+        addSource(_placeSearchResult) {
+            val combinedList = mutableListOf<PlaceSearchInfoList>()
+            combinedList.add(it.totalElements)
+            combinedList.addAll(it.placeInfoList)
+            value = combinedList
+        }
+    }
+    val searchResultsWithNum : LiveData<List<PlaceSearchInfoList>> get() = _searchResultsWithNum
+
+    init {
+        getBookmarkedPlaceList()
+    }
+
+    fun setStartDate(startDate: Date?){
+        _startDate.value = startDate
+    }
+
+    fun setEndDate(endDate : Date?){
+        _endDate.value = endDate
+    }
+
+    fun hasStartDate() : Boolean {
+        return startDate.value != null
+    }
+
+    private fun getBookmarkedPlaceList(){
+        viewModelScope.launch {
+            getPlaceBookmarkListUseCase().onSuccess {
+                _bookmarkedPlaces.postValue(it)
+            }.onError {
+                Log.e("getBookmarkedPlaceList", "onError $it")
+            }
+        }
+    }
+
+    fun initScheduleDetailInfo(planId: Long) {
+        viewModelScope.launch {
+            getScheduleDetailInfoUseCase.invoke(planId).onSuccess {
+                _originalSchedule.value = it
+                initScheduleData()
+            }
+        }
+    }
+
+    private fun initScheduleData() {
+        _originalSchedule.value?.let {
+            _startDate.value = dateStringToDate(it.startDate)
+            _endDate.value = dateStringToDate(it.endDate)
+            _title.value = it.title
+            _schedule.value = processScheduleInfoData(it.dailyPlans)
+        }
+    }
+
+    private fun dateStringToDate(dateString: String) : Date {
+        val formatter = SimpleDateFormat("yyyy-MM-dd", Locale.KOREA)
+        val date = formatter.parse(dateString) ?: Date()
+
+        return date
+    }
+
+    private fun processScheduleInfoData(plans: List<DailyPlan>) : List<DailySchedule>{
+        return plans.mapIndexed { index, dailyPlan ->
+            DailySchedule(
+                dailyIdx = index,
+                dailyDate = getDayNString(dailyPlan.dailyPlanDate, null, index),
+                dailyPlaces = dailyPlan.schedulePlaces.map { schedulePlace ->
+                    FormPlace(
+                        placeId = schedulePlace.placeId,
+                        placeName = schedulePlace.name,
+                        placeImage = "",
+                        placeCategory = schedulePlace.category
+
+                    )
+                }
+            )
+        }
+    }
+
+    private fun getDayNString(dateString: String = "", dateInfo: Date? = null, index: Int): String {
+        val date = when {
+            dateString.isNotEmpty() -> dateStringToDate(dateString)
+            dateInfo != null -> dateInfo
+            else -> throw IllegalArgumentException("date error")
+        }
+
+        val calendar = Calendar.getInstance()
+        calendar.time = date
+        calendar.add(Calendar.DAY_OF_MONTH, index)
+
+        val dayString = SimpleDateFormat("M월 d일 (E)", Locale.KOREAN).format(calendar.time)
+
+        return dayString
+    }
+
+    private fun formatDateValue(date: Date): String {
+        val dateFormat = SimpleDateFormat("yyyy.MM.dd(E)", Locale.KOREA)
+        val formattedDate = dateFormat.format(date)
+
+        return formattedDate
+    }
+
+    fun formatPickedDates() : String {
+        val startDateFormatted = _startDate.value?.let { formatDateValue(it) } ?: ""
+        val endDateFormatted = _endDate.value?.let { formatDateValue(it) } ?: ""
+        return "$startDateFormatted - $endDateFormatted"
+    }
+
+    fun isPeriodReset(){
+        val originalStart = _originalSchedule.value?.startDate?.let { dateStringToDate(it) }
+        val currentStart = _startDate.value
+
+        val originalEnd =_originalSchedule.value?.endDate?.let { dateStringToDate(it) }
+        val currentEnd =_endDate.value
+
+        val isStartDateChanged = originalStart==currentStart
+        val isEndDateChanged = originalEnd==currentEnd
+
+        if(!isStartDateChanged || !isEndDateChanged){
+            initScheduleList()
+        }
+    }
+
+    private fun initScheduleList() {
+        // 선택된 기간을 기준으로 리스트 초기화
+        val startDate = _startDate.value
+        val endDate = _endDate.value
+        if (startDate != null && endDate != null) {
+            val diffInMillies = kotlin.math.abs(endDate.time - startDate.time)
+            val diffInDays = TimeUnit.MILLISECONDS.toDays(diffInMillies).toInt()
+
+            val schedule = mutableListOf<DailySchedule>()
+            for (day in 0..diffInDays) {
+                val dateInfo = getDayNString("", startDate, day)
+                schedule.add(DailySchedule(day + 1, dateInfo, mutableListOf<FormPlace>()))
+            }
+
+            _schedule.value = schedule.toList()
+            Log.d("test1234", "_schedule.value: ${_schedule.value}")
+        }
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/vm/ModifyScheduleFormViewModelFactory.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/vm/ModifyScheduleFormViewModelFactory.kt
@@ -1,0 +1,41 @@
+package kr.tekit.lion.daongil.presentation.scheduleform.vm
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import kr.tekit.lion.daongil.domain.repository.BookmarkRepository
+import kr.tekit.lion.daongil.domain.repository.PlaceRepository
+import kr.tekit.lion.daongil.domain.repository.PlanRepository
+import kr.tekit.lion.daongil.domain.usecase.place.GetPlaceBookmarkListUseCase
+import kr.tekit.lion.daongil.domain.usecase.place.GetPlaceDetailInfoUseCase
+import kr.tekit.lion.daongil.domain.usecase.place.GetPlaceSearchResultUseCase
+import kr.tekit.lion.daongil.domain.usecase.plan.GetScheduleDetailInfoUseCase
+
+class ModifyScheduleFormViewModelFactory : ViewModelProvider.Factory {
+    private val getScheduleDetailInfoUseCase = GetScheduleDetailInfoUseCase(
+        PlanRepository.create()
+    )
+
+    private val getPlaceSearchResultUseCase = GetPlaceSearchResultUseCase(
+        PlanRepository.create()
+    )
+
+    private val getPlaceDetailInfoUseCase = GetPlaceDetailInfoUseCase(
+        PlaceRepository.create()
+    )
+
+    private val getPlaceBookmarkListUseCase = GetPlaceBookmarkListUseCase(
+        BookmarkRepository.create()
+    )
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if(modelClass.isAssignableFrom(ModifyScheduleFormViewModel::class.java)){
+            return ModifyScheduleFormViewModel(
+                getScheduleDetailInfoUseCase,
+                getPlaceSearchResultUseCase,
+                getPlaceDetailInfoUseCase,
+                getPlaceBookmarkListUseCase
+            ) as T
+        }
+        throw IllegalArgumentException("unknown ViewModel Class")
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/vm/ModifyScheduleFormViewModelFactory.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/vm/ModifyScheduleFormViewModelFactory.kt
@@ -9,6 +9,7 @@ import kr.tekit.lion.daongil.domain.usecase.place.GetPlaceBookmarkListUseCase
 import kr.tekit.lion.daongil.domain.usecase.place.GetPlaceDetailInfoUseCase
 import kr.tekit.lion.daongil.domain.usecase.place.GetPlaceSearchResultUseCase
 import kr.tekit.lion.daongil.domain.usecase.plan.GetScheduleDetailInfoUseCase
+import kr.tekit.lion.daongil.domain.usecase.plan.ModifyScheduleUseCase
 
 class ModifyScheduleFormViewModelFactory : ViewModelProvider.Factory {
     private val getScheduleDetailInfoUseCase = GetScheduleDetailInfoUseCase(
@@ -27,13 +28,18 @@ class ModifyScheduleFormViewModelFactory : ViewModelProvider.Factory {
         BookmarkRepository.create()
     )
 
+    private val modifyScheduleUseCase = ModifyScheduleUseCase(
+        PlanRepository.create()
+    )
+
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if(modelClass.isAssignableFrom(ModifyScheduleFormViewModel::class.java)){
             return ModifyScheduleFormViewModel(
                 getScheduleDetailInfoUseCase,
                 getPlaceSearchResultUseCase,
                 getPlaceDetailInfoUseCase,
-                getPlaceBookmarkListUseCase
+                getPlaceBookmarkListUseCase,
+                modifyScheduleUseCase
             ) as T
         }
         throw IllegalArgumentException("unknown ViewModel Class")

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/vm/ScheduleFormViewModel.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/vm/ScheduleFormViewModel.kt
@@ -134,12 +134,12 @@ class ScheduleFormViewModel(
         }
     }
 
-    fun getPlaceSearchResult(word: String, page: Int, size: Int){
+    fun getPlaceSearchResult(word: String, page: Int){
         _keyword.value = word
 
         // viewModelScope = ViewModel에 정의된 코루틴 스코프
         viewModelScope.launch {
-            getPlaceSearchResultUseCase(word, page, size)
+            getPlaceSearchResultUseCase(word, page)
                 .onSuccess {
                 // 검색 결과를 받아오면 _placeSearchResult에 값을 갱신해준다
                 _placeSearchResult.value = it
@@ -153,13 +153,13 @@ class ScheduleFormViewModel(
         return _placeSearchResult.value?.last ?: true
     }
 
-    fun fetchNextPlaceResults(size: Int) {
+    fun fetchNextPlaceResults() {
         val page = _placeSearchResult.value?.pageNo
         val keyword = _keyword.value
 
         if (keyword != null && page != null) {
             viewModelScope.launch {
-                getPlaceSearchResultUseCase(keyword, page + 1, size)
+                getPlaceSearchResultUseCase(keyword, page + 1)
                     .onSuccess {
                         // orEmpty() : null 인 경우 빈 리스트로 처리해준다.
                         val newList =

--- a/DaOnGil/app/src/main/res/layout/activity_modify_schedule_form.xml
+++ b/DaOnGil/app/src/main/res/layout/activity_modify_schedule_form.xml
@@ -7,4 +7,15 @@
     android:layout_height="match_parent"
     tools:context=".presentation.scheduleform.ModifyScheduleFormActivity">
 
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragmentModifyScheduleForm"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:defaultNavHost="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navGraph="@navigation/modify_schedule_form_graph" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/DaOnGil/app/src/main/res/layout/activity_modify_schedule_form.xml
+++ b/DaOnGil/app/src/main/res/layout/activity_modify_schedule_form.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".presentation.scheduleform.ModifyScheduleFormActivity">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/DaOnGil/app/src/main/res/layout/fragment_modify_name_period.xml
+++ b/DaOnGil/app/src/main/res/layout/fragment_modify_name_period.xml
@@ -1,8 +1,168 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/navi_background"
     tools:context=".presentation.scheduleform.fragment.ModifyNamePeriodFragment">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbarModifyNP"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/navi_background"
+        android:minHeight="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navigationIcon="@drawable/back_icon">
+
+        <TextView
+            style="@style/Theme.Toolbar.Title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/modify_schedule" />
+    </com.google.android.material.appbar.MaterialToolbar>
+
+    <LinearLayout
+        android:id="@+id/layoutModifyNPStep"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/toolbarModifyNP">
+
+        <View
+            android:layout_width="wrap_content"
+            android:layout_height="4dp"
+            android:layout_weight="1"
+            android:background="@color/primary"
+            android:visibility="visible" />
+
+        <View
+            android:layout_width="wrap_content"
+            android:layout_height="4dp"
+            android:layout_marginHorizontal="4dp"
+            android:layout_weight="1"
+            android:background="@color/schedule_detail_divider"
+            android:visibility="visible" />
+
+        <View
+            android:layout_width="wrap_content"
+            android:layout_height="4dp"
+            android:layout_weight="1"
+            android:background="@color/schedule_detail_divider"
+            android:visibility="visible" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/textViewModifyNPGuide"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin_basic"
+        android:layout_marginTop="45dp"
+        android:fontFamily="@font/pretendard_semibold"
+        android:text="@string/text_guide_modify_info"
+        android:textSize="24dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/layoutModifyNPStep" />
+
+    <TextView
+        android:id="@+id/textViewModifyNameTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin_basic"
+        android:layout_marginTop="@dimen/margin_big1"
+        android:fontFamily="@font/pretendard_medium"
+        android:text="@string/text_schedule_form_name"
+        android:textSize="@dimen/font_big1"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textViewModifyNPGuide" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/textInputModifyName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/margin_basic"
+        android:layout_marginTop="@dimen/margin_big3"
+        android:textColorHint="@color/text_tertiary"
+        app:boxBackgroundColor="@color/text_box_background"
+        app:boxCornerRadiusBottomEnd="10dp"
+        app:boxCornerRadiusBottomStart="10dp"
+        app:boxCornerRadiusTopEnd="10dp"
+        app:boxCornerRadiusTopStart="10dp"
+        app:boxStrokeWidth="0dp"
+        app:counterEnabled="true"
+        app:counterMaxLength="15"
+        app:endIconMode="clear_text"
+        app:errorEnabled="true"
+        app:hintEnabled="false"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textViewModifyNameTitle">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/editTextModifyName"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/pretendard_medium"
+            android:hint="@string/hint_schedule_form_name"
+            android:inputType="text"
+            android:maxLength="15"
+            android:maxLines="1"
+            android:textSize="@dimen/font_big3" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <TextView
+        android:id="@+id/textViewModifyPeriodTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin_basic"
+        android:layout_marginTop="@dimen/margin_big1"
+        android:enabled="false"
+        android:fontFamily="@font/pretendard_medium"
+        android:text="@string/text_schedule_form_period"
+        android:textSize="@dimen/font_big1"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textInputModifyName" />
+
+    <Button
+        android:id="@+id/buttonModifyPeriod"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin_basic"
+        android:layout_marginTop="@dimen/margin_big3"
+        android:layout_marginEnd="@dimen/margin_basic"
+        android:backgroundTint="@color/text_box_background"
+        android:fontFamily="@font/pretendard_regular"
+        android:gravity="start"
+        android:hint="@string/hint_schedule_form_period"
+        android:padding="@dimen/margin_big2"
+        android:textSize="@dimen/font_big2"
+        app:cornerRadius="10dp"
+        app:icon="@drawable/calendar_icon"
+        app:iconTint="@color/text_input_start_icon_tint"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textViewModifyPeriodTitle" />
+
+    <Button
+        android:id="@+id/buttonModifyNPNextStep"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginEnd="24dp"
+        android:layout_marginBottom="24dp"
+        android:background="@drawable/background_radius_10"
+        android:fontFamily="@font/pretendard_bold"
+        android:text="@string/text_schedule_form_next"
+        android:textSize="@dimen/font_big2"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/buttonModifyPeriod"
+        app:layout_constraintVertical_bias="1" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/DaOnGil/app/src/main/res/layout/fragment_modify_name_period.xml
+++ b/DaOnGil/app/src/main/res/layout/fragment_modify_name_period.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".presentation.scheduleform.fragment.ModifyNamePeriodFragment">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/DaOnGil/app/src/main/res/layout/fragment_modify_schedule_confirm.xml
+++ b/DaOnGil/app/src/main/res/layout/fragment_modify_schedule_confirm.xml
@@ -1,6 +1,111 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".presentation.scheduleform.fragment.ModifyScheduleConfirmFragment" />
+    android:background="@color/navi_background"
+    android:fillViewport="true"
+    tools:context=".presentation.scheduleform.fragment.ModifyScheduleConfirmFragment" >
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbarModifyConfirm"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/navi_background"
+            android:minHeight="?attr/actionBarSize"
+            app:navigationIcon="@drawable/back_icon">
+
+            <TextView
+                style="@style/Theme.Toolbar.Title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/modify_schedule" />
+        </com.google.android.material.appbar.MaterialToolbar>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <View
+                android:layout_width="wrap_content"
+                android:layout_height="4dp"
+                android:layout_weight="1"
+                android:background="@color/primary" />
+
+            <View
+                android:layout_width="wrap_content"
+                android:layout_height="4dp"
+                android:layout_marginHorizontal="4dp"
+                android:layout_weight="1"
+                android:background="@color/primary" />
+
+            <View
+                android:layout_width="wrap_content"
+                android:layout_height="4dp"
+                android:layout_weight="1"
+                android:background="@color/primary" />
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_basic"
+            android:layout_marginTop="45dp"
+            android:fontFamily="@font/pretendard_semibold"
+            android:text="@string/text_guide_confirm"
+            android:textSize="24dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/margin_basic"
+            android:layout_marginTop="@dimen/margin_big3"
+            android:layout_marginBottom="12dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/textViewModifyConfirmTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/pretendard_bold"
+                tools:text="@string/text_selected_title" />
+
+            <TextView
+                android:id="@+id/textViewModifyConfirmDate"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/pretendard_regular"
+                tools:text="@string/text_selected_period" />
+        </LinearLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerViewModifyConfirm"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="30dp"
+            android:layout_weight="1"
+            android:nestedScrollingEnabled="false"
+            android:overScrollMode="never"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+        <Button
+            android:id="@+id/buttonModifyConfirmSubmit"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_basic"
+            android:layout_marginTop="@dimen/margin_big1"
+            android:layout_marginEnd="@dimen/margin_basic"
+            android:layout_marginBottom="@dimen/margin_basic"
+            android:background="@drawable/background_radius_10"
+            android:fontFamily="@font/pretendard_bold"
+            android:text="@string/text_save_schedule_review"
+            android:textSize="@dimen/font_big2" />
+    </LinearLayout>
+</androidx.core.widget.NestedScrollView>

--- a/DaOnGil/app/src/main/res/layout/fragment_modify_schedule_confirm.xml
+++ b/DaOnGil/app/src/main/res/layout/fragment_modify_schedule_confirm.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".presentation.scheduleform.fragment.ModifyScheduleConfirmFragment" />

--- a/DaOnGil/app/src/main/res/layout/fragment_modify_schedule_details.xml
+++ b/DaOnGil/app/src/main/res/layout/fragment_modify_schedule_details.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".presentation.scheduleform.fragment.ModifyScheduleDetailsFragment" />

--- a/DaOnGil/app/src/main/res/layout/fragment_modify_schedule_details.xml
+++ b/DaOnGil/app/src/main/res/layout/fragment_modify_schedule_details.xml
@@ -1,6 +1,119 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".presentation.scheduleform.fragment.ModifyScheduleDetailsFragment" />
+    android:background="@color/navi_background"
+    android:fillViewport="true"
+    tools:context=".presentation.scheduleform.fragment.ModifyScheduleDetailsFragment" >
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbarModifyDetails"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/navi_background"
+            android:minHeight="?attr/actionBarSize"
+            app:navigationIcon="@drawable/back_icon">
+
+            <TextView
+                style="@style/Theme.Toolbar.Title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/modify_schedule" />
+        </com.google.android.material.appbar.MaterialToolbar>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <View
+                android:layout_width="wrap_content"
+                android:layout_height="4dp"
+                android:layout_weight="1"
+                android:background="@color/primary"
+                android:visibility="visible" />
+
+            <View
+                android:layout_width="wrap_content"
+                android:layout_height="4dp"
+                android:layout_marginHorizontal="4dp"
+                android:layout_weight="1"
+                android:background="@color/primary"
+                android:visibility="visible" />
+
+            <View
+                android:layout_width="wrap_content"
+                android:layout_height="4dp"
+                android:layout_weight="1"
+                android:background="@color/schedule_detail_divider"
+                android:visibility="visible" />
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_basic"
+            android:layout_marginTop="45dp"
+            android:fontFamily="@font/pretendard_semibold"
+            android:text="@string/text_guide_places"
+            android:textSize="24dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/margin_basic"
+            android:layout_marginTop="@dimen/margin_big3"
+            android:layout_marginBottom="12dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/textViewModifyDetailTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/pretendard_bold"
+                tools:text="@string/text_selected_title" />
+
+            <TextView
+                android:id="@+id/textViewModifyDetailDate"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/pretendard_regular"
+                tools:text="@string/text_selected_period" />
+        </LinearLayout>
+
+        <com.google.android.material.divider.MaterialDivider
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="12dp" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerViewModifyDetail"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="30dp"
+            android:layout_weight="1"
+            android:nestedScrollingEnabled="false"
+            android:overScrollMode="never"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+        <Button
+            android:id="@+id/buttonModifyDetailNextStep"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_basic"
+            android:layout_marginTop="@dimen/margin_big1"
+            android:layout_marginEnd="@dimen/margin_basic"
+            android:layout_marginBottom="@dimen/margin_basic"
+            android:background="@drawable/background_radius_10"
+            android:fontFamily="@font/pretendard_bold"
+            android:text="@string/text_schedule_form_next"
+            android:textSize="@dimen/font_big2" />
+    </LinearLayout>
+</androidx.core.widget.NestedScrollView>

--- a/DaOnGil/app/src/main/res/layout/fragment_modify_search.xml
+++ b/DaOnGil/app/src/main/res/layout/fragment_modify_search.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".presentation.scheduleform.fragment.ModifySearchFragment">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:backgroundTint="@color/white"
+        android:orientation="vertical">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbarModifySearch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/background_color"
+            android:minHeight="?attr/actionBarSize"
+            app:navigationIcon="@drawable/back_icon">
+
+            <TextView
+                style="@style/Theme.Toolbar.Title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/search_places_to_add" />
+        </com.google.android.material.appbar.MaterialToolbar>
+
+        <com.google.android.material.search.SearchBar
+            android:id="@+id/searchBarModifySearch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_search"
+            app:backgroundTint="@color/primary_disabled" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/margin_basic"
+            android:layout_marginTop="@dimen/margin_basic"
+            android:fontFamily="@font/pretendard_semibold"
+            android:text="@string/bookmarked_places"
+            android:textSize="@dimen/font_big3" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerViewModifyBookmark"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_big3"
+            android:paddingHorizontal="@dimen/margin_basic"
+            android:visibility="visible" />
+
+        <TextView
+            android:id="@+id/textViewModifyBookmarkEmpty"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/pretendard_medium"
+            android:gravity="center"
+            android:lineSpacingMultiplier="1.5"
+            android:padding="50dp"
+            android:text="@string/bookmarked_places_empty"
+            android:textAlignment="center"
+            android:textSize="@dimen/font_big3"
+            android:visibility="gone"
+            app:drawableTopCompat="@drawable/onboarding_clover" />
+    </LinearLayout>
+
+    <com.google.android.material.search.SearchView
+        android:id="@+id/searchViewModifySearchResult"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:backgroundTint="@color/background_color"
+        app:layout_anchor="@id/searchBarFS">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerViewModifySearchResult"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:backgroundTint="@color/background_color"
+            android:clipToPadding="false"
+            android:paddingVertical="@dimen/margin_basic"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+        <TextView
+            android:id="@+id/textViewModifySearchResultEmpty"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:fontFamily="@font/pretendard_medium"
+            android:gravity="center"
+            android:lineSpacingMultiplier="1.5"
+            android:text="@string/result_empty"
+            android:textAlignment="center"
+            android:textSize="@dimen/font_big3"
+            android:visibility="gone"
+            app:drawableTopCompat="@drawable/onboarding_clover" />
+    </com.google.android.material.search.SearchView>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/DaOnGil/app/src/main/res/layout/fragment_modify_search.xml
+++ b/DaOnGil/app/src/main/res/layout/fragment_modify_search.xml
@@ -71,7 +71,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:backgroundTint="@color/background_color"
-        app:layout_anchor="@id/searchBarFS">
+        app:layout_anchor="@id/searchBarModifySearch">
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/recyclerViewModifySearchResult"

--- a/DaOnGil/app/src/main/res/layout/fragment_schedule_details_form.xml
+++ b/DaOnGil/app/src/main/res/layout/fragment_schedule_details_form.xml
@@ -14,7 +14,7 @@
         android:orientation="vertical">
 
         <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbarModifyDetails"
+            android:id="@+id/toolbarScheduleDetailsForm"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@color/navi_background"

--- a/DaOnGil/app/src/main/res/layout/fragment_schedule_details_form.xml
+++ b/DaOnGil/app/src/main/res/layout/fragment_schedule_details_form.xml
@@ -14,7 +14,7 @@
         android:orientation="vertical">
 
         <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbarScheduleDetailsForm"
+            android:id="@+id/toolbarModifyDetails"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@color/navi_background"

--- a/DaOnGil/app/src/main/res/navigation/modify_schedule_form_graph.xml
+++ b/DaOnGil/app/src/main/res/navigation/modify_schedule_form_graph.xml
@@ -26,8 +26,8 @@
             android:id="@+id/action_modifyScheduleDetailsFragment_to_modifyScheduleConfirmFragment"
             app:destination="@id/modifyScheduleConfirmFragment" />
         <action
-            android:id="@+id/action_modifyScheduleDetailsFragment_to_formSearchFragment2"
-            app:destination="@id/formSearchFragment2" />
+            android:id="@+id/action_modifyScheduleDetailsFragment_to_modifySearchFragment"
+            app:destination="@id/modifySearchFragment" />
     </fragment>
     <fragment
         android:id="@+id/modifyScheduleConfirmFragment"
@@ -39,12 +39,12 @@
             app:destination="@id/modifyScheduleDetailsFragment" />
     </fragment>
     <fragment
-        android:id="@+id/formSearchFragment2"
-        android:name="kr.tekit.lion.daongil.presentation.scheduleform.fragment.FormSearchFragment"
+        android:id="@+id/modifySearchFragment"
+        android:name="kr.tekit.lion.daongil.presentation.scheduleform.fragment.ModifySearchFragment"
         android:label="@string/search_places_to_add"
-        tools:layout="@layout/fragment_form_search" >
+        tools:layout="@layout/fragment_modify_search" >
         <action
-            android:id="@+id/action_formSearchFragment2_to_modifyScheduleDetailsFragment"
+            android:id="@+id/action_modifySearchFragment_to_modifyScheduleDetailsFragment"
             app:destination="@id/modifyScheduleDetailsFragment" />
     </fragment>
 </navigation>

--- a/DaOnGil/app/src/main/res/navigation/modify_schedule_form_graph.xml
+++ b/DaOnGil/app/src/main/res/navigation/modify_schedule_form_graph.xml
@@ -46,5 +46,8 @@
         <action
             android:id="@+id/action_modifySearchFragment_to_modifyScheduleDetailsFragment"
             app:destination="@id/modifyScheduleDetailsFragment" />
+        <argument
+            android:name="schedulePosition"
+            app:argType="integer" />
     </fragment>
 </navigation>

--- a/DaOnGil/app/src/main/res/navigation/modify_schedule_form_graph.xml
+++ b/DaOnGil/app/src/main/res/navigation/modify_schedule_form_graph.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/modify_schedule_form_graph"
+    app:startDestination="@id/modifyNamePeriodFragment">
+
+    <fragment
+        android:id="@+id/modifyNamePeriodFragment"
+        android:name="kr.tekit.lion.daongil.presentation.scheduleform.fragment.ModifyNamePeriodFragment"
+        android:label="@string/modify_schedule"
+        tools:layout="@layout/fragment_modify_name_period" >
+        <action
+            android:id="@+id/action_modifyNamePeriodFragment_to_modifyScheduleDetailsFragment"
+            app:destination="@id/modifyScheduleDetailsFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/modifyScheduleDetailsFragment"
+        android:name="kr.tekit.lion.daongil.presentation.scheduleform.fragment.ModifyScheduleDetailsFragment"
+        android:label="@string/modify_schedule"
+        tools:layout="@layout/fragment_modify_schedule_details" >
+        <action
+            android:id="@+id/action_modifyScheduleDetailsFragment_to_modifyNamePeriodFragment"
+            app:destination="@id/modifyNamePeriodFragment" />
+        <action
+            android:id="@+id/action_modifyScheduleDetailsFragment_to_modifyScheduleConfirmFragment"
+            app:destination="@id/modifyScheduleConfirmFragment" />
+        <action
+            android:id="@+id/action_modifyScheduleDetailsFragment_to_formSearchFragment2"
+            app:destination="@id/formSearchFragment2" />
+    </fragment>
+    <fragment
+        android:id="@+id/modifyScheduleConfirmFragment"
+        android:name="kr.tekit.lion.daongil.presentation.scheduleform.fragment.ModifyScheduleConfirmFragment"
+        android:label="@string/modify_schedule"
+        tools:layout="@layout/fragment_modify_schedule_confirm" >
+        <action
+            android:id="@+id/action_modifyScheduleConfirmFragment_to_modifyScheduleDetailsFragment"
+            app:destination="@id/modifyScheduleDetailsFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/formSearchFragment2"
+        android:name="kr.tekit.lion.daongil.presentation.scheduleform.fragment.FormSearchFragment"
+        android:label="@string/search_places_to_add"
+        tools:layout="@layout/fragment_form_search" >
+        <action
+            android:id="@+id/action_formSearchFragment2_to_modifyScheduleDetailsFragment"
+            app:destination="@id/modifyScheduleDetailsFragment" />
+    </fragment>
+</navigation>

--- a/DaOnGil/app/src/main/res/values/strings.xml
+++ b/DaOnGil/app/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="result_empty">검색 결과가 없어요.\n다른 검색어를 입력해주세요.</string>
     <string name="bookmarked_places_empty">북마크한 여행지가 없어요.\n검색어를 입력해주세요.</string>
     <string name="add_new_schedule">새로운 일정</string>
+    <string name="modify_schedule">일정 수정</string>
     <string name="search_places_to_add">여행지 검색</string>
     <string name="confirm">확인</string>
     <string name="save">저장하기</string>

--- a/DaOnGil/app/src/main/res/values/strings.xml
+++ b/DaOnGil/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="save">저장하기</string>
     <string name="block_report">신고</string>
     <string name="text_guide_info">새로운 여행 정보를\n입력해주세요</string>
+    <string name="text_guide_modify_info">여행 정보를\n입력해주세요</string>
     <string name="text_guide_places">날짜마다 방문할\n여행지를 추가해주세요</string>
     <string name="text_guide_confirm">입력하신 여행정보를\n확인해보세요</string>
     <string name="text_number_of_result">검색결과 %s건</string>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #248

## 📝작업 내용

- 여행일정 수정 화면 UI 구현
- 여행일정 수정 API 연결

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인


## 스크린샷 (선택)
### (1)일정 수정 (영상 길이 때문에, 최대한 간단하게 수정했습니다)
https://github.com/user-attachments/assets/abf09591-67e6-4f99-acb0-bd02e4a37afe

### (2)여행 기간을 변경하는 경우
https://github.com/user-attachments/assets/d0e93750-9c62-4fa2-9736-a5e70b454b9e


## 💬리뷰 요구사항(선택)

- 일정 수정할 때 여행 기간을 다른 날짜로 바꾸는 경우, 기존 일정을 초기화 시켰습니다 (2번째 영상 참고해주세요!). 이 부분은 이대로 둬도 괜찮을까요? 아니면 기간이 변경되면 일정(여행지들)은 그대로 두고 날짜만 바뀌게 만들어야 할까요? 
- 여행 기간이 3일에서 2일로 변경되거나, 1일에서 2일로 변경될 때 (여행 기간이 달라질 때) 어떻게 하면 좋을 지 안 떠올라서 이런 식으로 작업하게 되었습니다!
