### PR TITLE
[#262] usecase 이름 변경으로 인한 오류 수정

### DIFF
--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/ScheduleDetailActivity.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/schedule/ScheduleDetailActivity.kt
@@ -24,7 +24,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
-import android.util.Log
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import kr.tekit.lion.daongil.domain.model.ScheduleDetail
@@ -36,6 +35,7 @@ import kr.tekit.lion.daongil.presentation.login.LoginActivity
 import kr.tekit.lion.daongil.presentation.schedule.ResultCode.RESULT_REVIEW_EDIT
 import kr.tekit.lion.daongil.presentation.schedule.ResultCode.RESULT_REVIEW_WRITE
 import kr.tekit.lion.daongil.presentation.schedule.ResultCode.RESULT_SCHEDULE_EDIT
+import kr.tekit.lion.daongil.presentation.scheduleform.ModifyScheduleFormActivity
 import kr.tekit.lion.daongil.presentation.schedulereview.ModifyScheduleReviewActivity
 import kr.tekit.lion.daongil.presentation.schedulereview.WriteScheduleReviewActivity
 import java.util.Timer
@@ -441,7 +441,10 @@ class ScheduleDetailActivity : AppCompatActivity(), ConfirmDialogInterface {
                 finish()
             },
             onScheduleEditClickListener = {
-                // 일정 수정 activity로
+                val newIntent =
+                    Intent(this@ScheduleDetailActivity, ModifyScheduleFormActivity::class.java)
+                newIntent.putExtra("planId", planId)
+                scheduleReviewLauncher.launch(newIntent)
             }).show(supportFragmentManager, "ScheduleManageBottomSheet")
     }
 

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ScheduleConfirmFormFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/fragment/ScheduleConfirmFormFragment.kt
@@ -1,6 +1,5 @@
 package kr.tekit.lion.daongil.presentation.scheduleform.fragment
 
-import android.app.Activity
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
@@ -10,6 +9,7 @@ import kr.tekit.lion.daongil.R
 import kr.tekit.lion.daongil.databinding.FragmentScheduleConfirmFormBinding
 import kr.tekit.lion.daongil.domain.model.DailySchedule
 import kr.tekit.lion.daongil.presentation.ext.showSnackbar
+import kr.tekit.lion.daongil.presentation.schedule.ResultCode
 import kr.tekit.lion.daongil.presentation.scheduleform.adapter.FormConfirmScheduleAdapter
 import kr.tekit.lion.daongil.presentation.scheduleform.vm.ScheduleFormViewModel
 import kr.tekit.lion.daongil.presentation.scheduleform.vm.ScheduleFormViewModelFactory
@@ -61,7 +61,7 @@ class ScheduleConfirmFormFragment : Fragment(R.layout.fragment_schedule_confirm_
         binding.buttonSConfirmFormSubmit.setOnClickListener { view ->
             scheduleFormViewModel.submitNewPlan{ _, requestFlag ->
                 if(requestFlag){
-                    requireActivity().setResult(Activity.RESULT_OK)
+                    requireActivity().setResult(ResultCode.RESULT_SCHEDULE_EDIT)
                     requireActivity().finish()
                 }else{
                     view.showSnackbar("다시 시도해주세요")

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/vm/ModifyScheduleFormViewModel.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/vm/ModifyScheduleFormViewModel.kt
@@ -21,14 +21,14 @@ import kr.tekit.lion.daongil.domain.usecase.base.onSuccess
 import kr.tekit.lion.daongil.domain.usecase.place.GetPlaceBookmarkListUseCase
 import kr.tekit.lion.daongil.domain.usecase.place.GetPlaceDetailInfoUseCase
 import kr.tekit.lion.daongil.domain.usecase.place.GetPlaceSearchResultUseCase
-import kr.tekit.lion.daongil.domain.usecase.plan.GetScheduleDetailInfoUseCase
+import kr.tekit.lion.daongil.domain.usecase.plan.GetScheduleDetailUseCase
 import kr.tekit.lion.daongil.domain.usecase.plan.ModifyScheduleUseCase
 import java.text.SimpleDateFormat
 import java.util.*
 import java.util.concurrent.TimeUnit
 
 class ModifyScheduleFormViewModel (
-    private val getScheduleDetailInfoUseCase: GetScheduleDetailInfoUseCase,
+    private val getScheduleDetailInfoUseCase: GetScheduleDetailUseCase,
     private val getPlaceSearchResultUseCase: GetPlaceSearchResultUseCase,
     private val getPlaceDetailInfoUseCase: GetPlaceDetailInfoUseCase,
     private val getPlaceBookmarkListUseCase: GetPlaceBookmarkListUseCase,

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/vm/ModifyScheduleFormViewModelFactory.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/scheduleform/vm/ModifyScheduleFormViewModelFactory.kt
@@ -8,11 +8,11 @@ import kr.tekit.lion.daongil.domain.repository.PlanRepository
 import kr.tekit.lion.daongil.domain.usecase.place.GetPlaceBookmarkListUseCase
 import kr.tekit.lion.daongil.domain.usecase.place.GetPlaceDetailInfoUseCase
 import kr.tekit.lion.daongil.domain.usecase.place.GetPlaceSearchResultUseCase
-import kr.tekit.lion.daongil.domain.usecase.plan.GetScheduleDetailInfoUseCase
+import kr.tekit.lion.daongil.domain.usecase.plan.GetScheduleDetailUseCase
 import kr.tekit.lion.daongil.domain.usecase.plan.ModifyScheduleUseCase
 
 class ModifyScheduleFormViewModelFactory : ViewModelProvider.Factory {
-    private val getScheduleDetailInfoUseCase = GetScheduleDetailInfoUseCase(
+    private val getScheduleDetailInfoUseCase = GetScheduleDetailUseCase(
         PlanRepository.create()
     )
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #262

## 📝작업 내용

- UseCase 이름 변경 
- 일정 화면 -> 일정 수정 화면 연결

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
https://github.com/user-attachments/assets/02add883-95d4-4d03-8dae-1303ca626458


## 💬리뷰 요구사항(선택)

- 예인님께 요청드릴 부분이 있습니다!
- 일정 수정 view model 수정된 내용을 테스트하려고 했는데, 수정 버튼을 눌러도 수정 화면으로 넘어가지 않더라구요. 테스트 하려고 ScheduleDetailActivity하고 일정 수정 화면 연결했습니다. 그리고 수정된 내용이 서버에 잘 반영되었는지 바로 확인하려고 예인님이 설정한 result code 넣어서 테스트 해봤는데 잘 되더라구요~ 이렇게만 코드 넣어주면 되는 게 맞을까요?  (이 부분은 연결한 김에 같이 커밋남겼습니다.)

