### PR TITLE
[#273] 관심유형 선택 리팩토링

### DIFF
--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/login/fragment/ConcernTypeSelectFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/login/fragment/ConcernTypeSelectFragment.kt
@@ -1,4 +1,4 @@
-package kr.tekit.lion.daongil.presentation.concerntype.fragment
+package kr.tekit.lion.daongil.presentation.login.fragment
 
 import android.content.Intent
 import android.os.Bundle
@@ -6,7 +6,6 @@ import androidx.fragment.app.Fragment
 import android.view.View
 import android.widget.ImageView
 import androidx.fragment.app.activityViewModels
-import androidx.navigation.fragment.findNavController
 import kr.tekit.lion.daongil.R
 import kr.tekit.lion.daongil.databinding.FragmentConcernTypeSelectBinding
 import kr.tekit.lion.daongil.domain.model.ConcernType

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/login/fragment/ConcernTypeSelectFragment.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/login/fragment/ConcernTypeSelectFragment.kt
@@ -5,17 +5,17 @@ import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.View
 import android.widget.ImageView
-import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import kr.tekit.lion.daongil.R
 import kr.tekit.lion.daongil.databinding.FragmentConcernTypeSelectBinding
 import kr.tekit.lion.daongil.domain.model.ConcernType
-import kr.tekit.lion.daongil.presentation.concerntype.vm.ConcernTypeViewModel
-import kr.tekit.lion.daongil.presentation.concerntype.vm.ConcernTypeViewModelFactory
+import kr.tekit.lion.daongil.presentation.login.vm.ConcernTypeSelectViewModel
+import kr.tekit.lion.daongil.presentation.login.vm.ConcernTypeSelectViewModelFactory
 import kr.tekit.lion.daongil.presentation.main.MainActivity
 
 class ConcernTypeSelectFragment : Fragment(R.layout.fragment_concern_type_select) {
 
-    private val viewModel: ConcernTypeViewModel by activityViewModels { ConcernTypeViewModelFactory() }
+    private val viewModel: ConcernTypeSelectViewModel by viewModels { ConcernTypeSelectViewModelFactory() }
 
     private val selectedConcernType = mutableSetOf<Int>()
 
@@ -25,7 +25,6 @@ class ConcernTypeSelectFragment : Fragment(R.layout.fragment_concern_type_select
         val binding = FragmentConcernTypeSelectBinding.bind(view)
 
         initSelectConcernType(binding)
-        observeSelection(binding)
         concernTypeSelect(binding)
     }
 
@@ -51,39 +50,6 @@ class ConcernTypeSelectFragment : Fragment(R.layout.fragment_concern_type_select
                 toggleSelection(it as ImageView, R.drawable.elderly_people_no_select, R.drawable.elderly_people_select, binding)
             }
         }
-    }
-
-    private fun observeSelection(binding: FragmentConcernTypeSelectBinding) {
-        viewModel.concernType.observe(viewLifecycleOwner) { concernType ->
-            initSelectionState(binding, concernType)
-        }
-    }
-
-    private fun initSelectionState(binding: FragmentConcernTypeSelectBinding, concernType: ConcernType) {
-        with(binding) {
-            if (concernType.isPhysical) {
-                settingSelected(physicalDisabilityImageView, R.drawable.physical_select)
-            }
-            if (concernType.isVisual) {
-                settingSelected(visualImpairmentImageView, R.drawable.visual_select)
-            }
-            if (concernType.isHear) {
-                settingSelected(hearingImpairmentImageView, R.drawable.hearing_select)
-            }
-            if (concernType.isChild) {
-                settingSelected(infantFamilyImageView, R.drawable.infant_family_select)
-            }
-            if (concernType.isElderly) {
-                settingSelected(elderlyPeopleImageView, R.drawable.elderly_people_select)
-            }
-        }
-        updateCompleteButtonState(binding)
-    }
-
-    private fun settingSelected(imageView: ImageView, selectedDrawable: Int) {
-        imageView.setImageResource(selectedDrawable)
-        imageView.tag = "true"
-        selectedConcernType.add(imageView.id)
     }
 
     private fun toggleSelection(imageView: ImageView, unselectedDrawable: Int, selectedDrawable: Int, binding: FragmentConcernTypeSelectBinding) {
@@ -113,7 +79,7 @@ class ConcernTypeSelectFragment : Fragment(R.layout.fragment_concern_type_select
                  val isChild = binding.infantFamilyImageView.tag?.toString()?.toBoolean() ?: false
                  val isElderly = binding.elderlyPeopleImageView.tag?.toString()?.toBoolean() ?: false
 
-                 viewModel.updateConcernType(ConcernType(isPhysical, isHear, isVisual, isElderly, isChild))
+                 viewModel.selectConcernType(ConcernType(isPhysical, isHear, isVisual, isElderly, isChild))
 
                  val intent = Intent(requireActivity(), MainActivity::class.java)
                  startActivity(intent)

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/login/vm/ConcernTypeSelectViewModel.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/login/vm/ConcernTypeSelectViewModel.kt
@@ -1,0 +1,23 @@
+package kr.tekit.lion.daongil.presentation.login.vm
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import kr.tekit.lion.daongil.domain.model.ConcernType
+import kr.tekit.lion.daongil.domain.usecase.base.onError
+import kr.tekit.lion.daongil.domain.usecase.base.onSuccess
+import kr.tekit.lion.daongil.domain.usecase.myinfo.UpdateConcernTypeUseCase
+
+class ConcernTypeSelectViewModel(
+    private val updateConcernTypeUseCase: UpdateConcernTypeUseCase
+) : ViewModel() {
+
+    fun selectConcernType(requestBody: ConcernType) = viewModelScope.launch {
+        updateConcernTypeUseCase(requestBody).onSuccess {
+            Log.d("selectConcernType", it.toString())
+        }.onError {
+            Log.d("selectConcernType", it.toString())
+        }
+    }
+}

--- a/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/login/vm/ConcernTypeSelectViewModelFactory.kt
+++ b/DaOnGil/app/src/main/java/kr/tekit/lion/daongil/presentation/login/vm/ConcernTypeSelectViewModelFactory.kt
@@ -1,0 +1,19 @@
+package kr.tekit.lion.daongil.presentation.login.vm
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import kr.tekit.lion.daongil.domain.repository.MemberRepository
+import kr.tekit.lion.daongil.domain.usecase.myinfo.UpdateConcernTypeUseCase
+
+class ConcernTypeSelectViewModelFactory : ViewModelProvider.Factory {
+
+    private val memberRepository = MemberRepository.create()
+    private val updateConcernTypeUseCase = UpdateConcernTypeUseCase(memberRepository)
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(ConcernTypeSelectViewModel::class.java)) {
+            return ConcernTypeSelectViewModel(updateConcernTypeUseCase) as T
+        }
+        throw IllegalArgumentException("unknown ViewModel class")
+    }
+}

--- a/DaOnGil/app/src/main/res/layout/fragment_concern_type_select.xml
+++ b/DaOnGil/app/src/main/res/layout/fragment_concern_type_select.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    tools:context=".presentation.concerntype.fragment.ConcernTypeSelectFragment" >
+    tools:context=".presentation.login.fragment.ConcernTypeSelectFragment" >
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/selectInterestToolbar"

--- a/DaOnGil/app/src/main/res/navigation/login_navigation_graph.xml
+++ b/DaOnGil/app/src/main/res/navigation/login_navigation_graph.xml
@@ -16,7 +16,7 @@
     </fragment>
     <fragment
         android:id="@+id/concernTypeSelectFragment"
-        android:name="kr.tekit.lion.daongil.presentation.concerntype.fragment.ConcernTypeSelectFragment"
+        android:name="kr.tekit.lion.daongil.presentation.login.fragment.ConcernTypeSelectFragment"
         android:label="ConcernTypeSelectFragment" >
         <action
             android:id="@+id/action_concernTypeSelectFragment_to_loginFragment"


### PR DESCRIPTION
## #️⃣연관된 이슈

- #273 

## 📝작업 내용

- 첫 로그인 시 관심 유형 선택 fragment의 패키지 login 패키지로 이동
- viewModel 변경 및 불필요한 코드 삭제

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인


## 💬리뷰 요구사항(선택)

- 패키지 변경, 관심 유형 선택 viewModel 만들어서 변경, 불필요한 코드 삭제했는데 잘 수정되었는지 확인 부탁드립니다!
